### PR TITLE
feat(geom): extract numeric math utils and refactor circle

### DIFF
--- a/src/geom/math.ts
+++ b/src/geom/math.ts
@@ -1,0 +1,27 @@
+import type { Vec } from "./types";
+
+/**
+ * Euclidean distance between two points.
+ */
+export function distance(a: Vec, b: Vec): number {
+    return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
+/**
+ * Numerically safe square root.
+ * - For small negative inputs within |x| <= eps, returns 0.
+ * - For negative inputs beyond the epsilon, returns NaN to signal invalid.
+ */
+export function safeSqrt(x: number, eps = 1e-15): number {
+    if (x < 0) {
+        return x >= -Math.abs(eps) ? 0 : NaN;
+    }
+    return Math.sqrt(x);
+}
+
+/**
+ * Rotate a vector by +90 degrees: (x, y) -> (-y, x).
+ */
+export function perp90(v: Vec): Vec {
+    return { x: -v.y, y: v.x };
+}

--- a/tests/unit/geom/math.safeSqrt.test.ts
+++ b/tests/unit/geom/math.safeSqrt.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from "vitest";
+import { safeSqrt } from "../../../src/geom/math";
+
+describe("math.safeSqrt", () => {
+    it("clamps small negative to 0", () => {
+        expect(safeSqrt(-1e-15)).toBe(0);
+    });
+
+    it("computes sqrt for positive numbers", () => {
+        expect(safeSqrt(4)).toBe(2);
+    });
+});


### PR DESCRIPTION
Closes #8

Summary
- Extract common math utilities: `distance`, `safeSqrt`, `perp90` under `src/geom/math.ts`.
- Refactor `src/geom/circle.ts` to use the new utilities.
- Add unit test for `safeSqrt` behavior.

Motivation
- Centralize numerical helpers to improve readability and reuse across geometry modules, per Issue #8.

Changes
- Added: `src/geom/math.ts`
- Updated: `src/geom/circle.ts` (h² clamping -> safeSqrt, direction offset via perp90)
- Added test: `tests/unit/geom/math.safeSqrt.test.ts`

Verification
- Locally: `pnpm run test:sandbox` → all tests green (property/acceptance/unit).
- Typecheck and lint pass locally.

Risks/Notes
- No behavior change intended; classification and point coordinates remain identical within tolerances.
- Acceptance tests unchanged.

Out of scope
- Publishing sort function as public util (#6)
- -0 normalization (#7)

Follow-ups
- Proceed with #6 → replace local sort with shared util, then #7.

Checklist
- [x] Tests added / updated
- [x] No acceptance test changes
- [x] Conventional Commits used
- [x] TSDoc unchanged as this is internal refactor
