### PR TITLE
feat(geom): geodesic from two boundary points (circle/diameter)

### DIFF
--- a/src/geom/geodesic.ts
+++ b/src/geom/geodesic.ts
@@ -1,0 +1,59 @@
+import type { Vec } from "./types";
+import { defaultTol, tolValue } from "./types";
+
+export type GeodesicCircle = { kind: "circle"; c: Vec; r: number };
+export type GeodesicDiameter = { kind: "diameter"; dir: Vec };
+export type Geodesic = GeodesicCircle | GeodesicDiameter;
+
+function isOpposite(a: Vec, b: Vec): boolean {
+    // a ≈ -b  <=>  |a + b| ≈ 0
+    const s = { x: a.x + b.x, y: a.y + b.y };
+    const eps = tolValue(1, defaultTol);
+    return Math.hypot(s.x, s.y) <= eps;
+}
+
+function solveCenterFromDot1(a: Vec, b: Vec): Vec {
+    // Solve for c such that a·c = 1 and b·c = 1
+    const det = a.x * b.y - a.y * b.x;
+    const eps = tolValue(1, defaultTol);
+    if (Math.abs(det) <= eps) {
+        throw new Error("Degenerate boundary pair: nearly equal or opposite");
+    }
+    const cx = (b.y - a.y) / det;
+    const cy = (a.x - b.x) / det;
+    return { x: cx, y: cy };
+}
+
+function normalize(v: Vec): Vec {
+    const n = Math.hypot(v.x, v.y);
+    if (!(n > 0) || !Number.isFinite(n)) return { x: 1, y: 0 };
+    return { x: v.x / n, y: v.y / n };
+}
+
+/**
+ * geodesicFromBoundary
+ * Construct the Poincaré disk geodesic determined by two boundary points a,b.
+ * - If a and b are opposite on the unit circle, returns a diameter through the origin with unit direction `dir`.
+ * - Otherwise returns the unique circle orthogonal to the unit circle passing through a and b.
+ *   The circle center c satisfies a·c = b·c = 1 and |c|^2 = 1 + r^2.
+ *
+ * Constraints: a and b should lie on the unit circle and be distinct.
+ * Degenerate inputs (a≈b, singular system) throw an Error.
+ */
+export function geodesicFromBoundary(a: Vec, b: Vec): Geodesic {
+    if (!Number.isFinite(a.x) || !Number.isFinite(a.y) || !Number.isFinite(b.x) || !Number.isFinite(b.y)) {
+        throw new Error("Non-finite boundary point");
+    }
+    // Equal endpoints guard
+    const eq = Math.hypot(a.x - b.x, a.y - b.y) <= tolValue(1, defaultTol);
+    if (eq) throw new Error("Degenerate boundary pair: identical points");
+
+    if (isOpposite(a, b)) {
+        return { kind: "diameter", dir: normalize(a) };
+    }
+
+    const c = solveCenterFromDot1(a, b);
+    // Prefer geometric radius from endpoint to improve stability for nearly coincident endpoints
+    const r = Math.hypot(a.x - c.x, a.y - c.y);
+    return { kind: "circle", c, r };
+}

--- a/tests/property/geodesic.properties.test.ts
+++ b/tests/property/geodesic.properties.test.ts
@@ -1,0 +1,45 @@
+import { test, fc } from "@fast-check/vitest";
+import { geodesicFromBoundary } from "../../src/geom/geodesic";
+import type { Vec } from "../../src/geom/types";
+
+const pt = (t: number): Vec => ({ x: Math.cos(t), y: Math.sin(t) });
+const add = (a: Vec, b: Vec): Vec => ({ x: a.x + b.x, y: a.y + b.y });
+const norm = (v: Vec): number => Math.hypot(v.x, v.y);
+const dot = (a: Vec, b: Vec): number => a.x * b.x + a.y * b.y;
+const eps = (scale = 1) => 1e-12 * Math.max(1, scale);
+
+const angleArb = fc.double({
+    min: -5 * Math.PI,
+    max: 5 * Math.PI,
+    noNaN: true,
+    noDefaultInfinity: true,
+});
+
+test.prop([angleArb, angleArb])("geodesic classification and invariants", (t1, t2) => {
+    // Avoid near-equal endpoints: use sin((t2-t1)/2) which is stable for tiny differences
+    fc.pre(Math.abs(Math.sin(0.5 * (t2 - t1))) > 1e-6);
+    const a = pt(t1);
+    const b = pt(t2);
+    const opp = norm(add(a, b)) <= 1e-12; // a ≈ -b
+    const g = geodesicFromBoundary(a, b);
+    if (opp) {
+        // diameter: dir is unit and parallel to a
+        if (g.kind !== "diameter") return false;
+        if (Math.abs(norm(g.dir) - 1) > 1e-12) return false;
+        const cross = g.dir.x * a.y - g.dir.y * a.x;
+        return Math.abs(cross) <= 1e-12;
+    } else {
+        if (g.kind !== "circle") return false;
+        // invariants (with scale-aware tolerance for ill-conditioned cases)
+        const da = Math.hypot(a.x - g.c.x, a.y - g.c.y);
+        const db = Math.hypot(b.x - g.c.x, b.y - g.c.y);
+        const eR = 1e-12 + 1e-4 * g.r; // absolute + relative (for tiny/huge radius)
+        if (Math.abs(da - g.r) > eR) return false;
+        if (Math.abs(db - g.r) > eR) return false;
+        const c2 = g.c.x * g.c.x + g.c.y * g.c.y;
+        if (Math.abs(c2 - (1 + g.r * g.r)) > eps(c2)) return false;
+        if (Math.abs(dot(a, g.c) - 1) > eps(1)) return false;
+        if (Math.abs(dot(b, g.c) - 1) > eps(1)) return false;
+        return true;
+    }
+});

--- a/tests/unit/geom/geodesic.unit.test.ts
+++ b/tests/unit/geom/geodesic.unit.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { geodesicFromBoundary } from "../../../src/geom/geodesic";
+import type { Vec } from "../../../src/geom/types";
+
+const pt = (t: number): Vec => ({ x: Math.cos(t), y: Math.sin(t) });
+const dot = (a: Vec, b: Vec) => a.x * b.x + a.y * b.y;
+const norm2 = (v: Vec) => v.x * v.x + v.y * v.y;
+
+describe("geodesicFromBoundary", () => {
+    it("returns circle kind for generic pair (not opposite)", () => {
+        const a = pt(0.3);
+        const b = pt(1.7);
+        const g = geodesicFromBoundary(a, b);
+        if (g.kind !== "circle") throw new Error("expected circle kind");
+        // passes through endpoints
+        const da = Math.hypot(a.x - g.c.x, a.y - g.c.y);
+        const db = Math.hypot(b.x - g.c.x, b.y - g.c.y);
+        expect(da).toBeCloseTo(g.r, 12);
+        expect(db).toBeCloseTo(g.r, 12);
+        // orthogonality: |c|^2 = 1 + r^2
+        expect(norm2(g.c)).toBeCloseTo(1 + g.r * g.r, 12);
+        // alternative condition: a·c = b·c = 1
+        expect(dot(a, g.c)).toBeCloseTo(1, 12);
+        expect(dot(b, g.c)).toBeCloseTo(1, 12);
+    });
+
+    it("returns diameter for opposite endpoints", () => {
+        const a = pt(0.8);
+        const b = pt(0.8 + Math.PI);
+        const g = geodesicFromBoundary(a, b);
+        if (g.kind !== "diameter") throw new Error("expected diameter kind");
+        // dir should be parallel to a (or -a)
+        const cross = g.dir.x * a.y - g.dir.y * a.x;
+        expect(Math.abs(cross)).toBeCloseTo(0, 12);
+        // dir is unit
+        expect(Math.hypot(g.dir.x, g.dir.y)).toBeCloseTo(1, 12);
+    });
+
+    it("throws on degenerate equal endpoints", () => {
+        const a = pt(-0.2);
+        expect(() => geodesicFromBoundary(a, a)).toThrow();
+    });
+});


### PR DESCRIPTION
Closes #12

Summary
- Implement `geodesicFromBoundary(a,b)` in `src/geom/geodesic.ts`
  - Returns `{kind:'diameter', dir}` if endpoints are opposite
  - Else returns `{kind:'circle', c, r}` with constraints: `a·c = b·c = 1`, `|c|^2 = 1 + r^2`
- Tests
  - Unit tests for circle/diameter classification and invariants
  - Property test (fast-check): classification and invariants across random angles
    - Uses scale-aware tolerances; excludes near-degenerate pairs where angles are almost identical (ill-conditioned)

Notes
- For numerical stability with near-coincident endpoints, radius is taken as the geometric distance from the center to one endpoint; orthogonality is validated with scaled tolerance.
- No changes to acceptance tests.

Verification
- `pnpm run test:sandbox` → all tests green
- Typecheck and lint pass locally (lint shows warnings in locked acceptance tests only)
