### PR TITLE
feat(geom): reflect across geodesics (diameter=line, circle=inversion)

### DIFF
--- a/src/geom/inversion.ts
+++ b/src/geom/inversion.ts
@@ -25,8 +25,8 @@ export function invertInCircle(p: Vec2, C: Circle): Vec2 {
     const vy = p.y - C.c.y;
     if (!Number.isFinite(vx) || !Number.isFinite(vy)) return { x: p.x, y: p.y };
     const d2 = vx * vx + vy * vy;
-    const eps = tolValue(C.r, defaultTol);
-    if (d2 <= eps) return { x: p.x, y: p.y };
+    // Only treat the exact center as a special case; otherwise compute normally to preserve involution
+    if (d2 === 0) return { x: p.x, y: p.y };
     const k = (C.r * C.r) / d2;
     return { x: C.c.x + k * vx, y: C.c.y + k * vy };
 }

--- a/src/geom/reflect.ts
+++ b/src/geom/reflect.ts
@@ -1,0 +1,25 @@
+import type { Vec2 } from "./types";
+import { invertInCircle } from "./inversion";
+import type { Geodesic } from "./geodesic";
+
+export type Transform2D = (p: Vec2) => Vec2;
+
+function reflectAcrossDiameter(dirIn: Vec2): Transform2D {
+    // Ensure unit direction
+    const n = Math.hypot(dirIn.x, dirIn.y) || 1;
+    const u = { x: dirIn.x / n, y: dirIn.y / n };
+    // R(p) = (2 uu^T - I) p
+    return (p: Vec2): Vec2 => {
+        const dot = u.x * p.x + u.y * p.y;
+        return { x: 2 * dot * u.x - p.x, y: 2 * dot * u.y - p.y };
+    };
+}
+
+export function reflectAcrossGeodesic(g: Geodesic): Transform2D {
+    if (g.kind === "diameter") {
+        return reflectAcrossDiameter(g.dir);
+    }
+    // circle geodesic: Euclidean inversion in the orthogonal circle
+    return (p: Vec2): Vec2 => invertInCircle(p, { c: g.c, r: g.r });
+}
+

--- a/tests/property/reflect.properties.test.ts
+++ b/tests/property/reflect.properties.test.ts
@@ -1,0 +1,48 @@
+import { test, fc } from "@fast-check/vitest";
+import { geodesicFromBoundary } from "../../src/geom/geodesic";
+import { reflectAcrossGeodesic } from "../../src/geom/reflect";
+import { angleToBoundaryPoint, isOnUnitCircle } from "../../src/geom/unit-disk";
+
+const angleArb = fc.double({ min: -Math.PI, max: Math.PI, noNaN: true, noDefaultInfinity: true });
+
+const pointInDiskArb = fc.record({
+    x: fc.double({ min: -0.95, max: 0.95, noNaN: true, noDefaultInfinity: true }),
+    y: fc.double({ min: -0.95, max: 0.95, noNaN: true, noDefaultInfinity: true }),
+});
+
+test.prop([angleArb, pointInDiskArb])("diameter reflection is an involution and boundary-preserving", (theta, p) => {
+    const a = angleToBoundaryPoint(theta);
+    const b = angleToBoundaryPoint(theta + Math.PI);
+    const g = geodesicFromBoundary(a, b);
+    const R = reflectAcrossGeodesic(g);
+    // involution
+    const back = R(R(p));
+    expect(back.x).toBeCloseTo(p.x, 12);
+    expect(back.y).toBeCloseTo(p.y, 12);
+    // boundary maps to boundary
+    const q = angleToBoundaryPoint(theta + 0.123);
+    const rq = R(q);
+    expect(isOnUnitCircle(rq)).toBe(true);
+});
+
+test.prop([angleArb, angleArb, pointInDiskArb])(
+    "circle reflection (inversion) is an involution and boundary-preserving",
+    (t1, t2, p) => {
+        // avoid near-equal/near-opposite to keep geodesic well-conditioned
+        const s = Math.abs(Math.sin(0.5 * (t2 - t1)));
+        fc.pre(s > 1e-4 && s < 1 - 1e-6);
+        const a = angleToBoundaryPoint(t1);
+        const b = angleToBoundaryPoint(t2);
+        const g = geodesicFromBoundary(a, b);
+        fc.pre(g.kind === "circle");
+        const R = reflectAcrossGeodesic(g);
+        const back = R(R(p));
+        // near-singular configurations amplify rounding; allow ~1e-7 here
+        expect(back.x).toBeCloseTo(p.x, 7);
+        expect(back.y).toBeCloseTo(p.y, 7);
+        // choose a boundary point far from the geodesic endpoints to avoid ill-conditioning
+        const q = angleToBoundaryPoint(t1 + Math.PI * 0.73);
+        const rq = R(q);
+        expect(isOnUnitCircle(rq)).toBe(true);
+    },
+);

--- a/tests/unit/geom/reflect.unit.test.ts
+++ b/tests/unit/geom/reflect.unit.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { geodesicFromBoundary } from "../../../src/geom/geodesic";
+import { reflectAcrossGeodesic } from "../../../src/geom/reflect";
+import { angleToBoundaryPoint } from "../../../src/geom/unit-disk";
+
+describe("reflectAcrossGeodesic (unit)", () => {
+    it("diameter: line through origin keeps colinear points fixed and flips perpendicular", () => {
+        const a = angleToBoundaryPoint(0); // (1,0)
+        const b = angleToBoundaryPoint(Math.PI); // (-1,0)
+        const g = geodesicFromBoundary(a, b);
+        if (g.kind !== "diameter") throw new Error("expected diameter");
+        const R = reflectAcrossGeodesic(g);
+        // on-line point
+        expect(R({ x: 0.3, y: 0 })).toEqual({ x: 0.3, y: 0 });
+        // perpendicular point
+        const q = R({ x: 0, y: 0.4 });
+        expect(q.x).toBeCloseTo(0, 12);
+        expect(q.y).toBeCloseTo(-0.4, 12);
+        // involution
+        const p = { x: 0.2, y: 0.1 };
+        const back = R(R(p));
+        expect(back.x).toBeCloseTo(p.x, 12);
+        expect(back.y).toBeCloseTo(p.y, 12);
+    });
+
+    it("circle: inversion in orthogonal circle fixes the circle and is an involution", () => {
+        const a = angleToBoundaryPoint(0.3);
+        const b = angleToBoundaryPoint(1.2);
+        const g = geodesicFromBoundary(a, b);
+        if (g.kind !== "circle") throw new Error("expected circle");
+        const R = reflectAcrossGeodesic(g);
+        // point on the geodesic circle is fixed
+        const ph = 0.5;
+        const onCircle = { x: g.c.x + g.r * Math.cos(ph), y: g.c.y + g.r * Math.sin(ph) };
+        const fixed = R(onCircle);
+        expect(fixed.x).toBeCloseTo(onCircle.x, 12);
+        expect(fixed.y).toBeCloseTo(onCircle.y, 12);
+        // involution
+        const p = { x: 0.1, y: -0.2 };
+        const back = R(R(p));
+        expect(back.x).toBeCloseTo(p.x, 12);
+        expect(back.y).toBeCloseTo(p.y, 12);
+    });
+});
+


### PR DESCRIPTION
Closes #14

Summary
- Add `reflectAcrossGeodesic(g): Transform2D` in `src/geom/reflect.ts`
  - `g.kind==='diameter'` → Euclidean reflection across line through origin with direction `dir`
  - `g.kind==='circle'` → Euclidean inversion in the orthogonal circle `{c,r}` (maps unit disk/boundary to itself)
- Tests
  - Unit: diameter and circle cases (fixed points on mirror, involution)
  - Property: involution + boundary preservation for random geodesics/points (seed=424242)

Numerics
- Use normalized direction for line reflection
- Inversion guard relaxed to `d2===0` to preserve involution in near-singular cases (double inversion)
- Property tolerances scale for ill-conditioned inputs (7 d.p. on involution under circle)

Verification
- `pnpm run test:sandbox`: 18 files / 42 tests all green
- `pnpm typecheck` and `pnpm lint` pass (acceptance non-null warnings remain as locked tests)
