### PR TITLE
feat(geom): add angle snap utilities (snapAngle/snapBoundaryPoint)

### DIFF
--- a/src/geom/snap.ts
+++ b/src/geom/snap.ts
@@ -1,0 +1,42 @@
+import type { Vec2 } from "./types";
+import { angleToBoundaryPoint, boundaryPointToAngle } from "./unit-disk";
+
+const TAU = 2 * Math.PI;
+
+function normalize0ToTau(theta: number): number {
+    let t = theta % TAU;
+    if (t < 0) t += TAU;
+    return t;
+}
+
+function normalizeMinusPiToPi(theta: number): number {
+    let t = ((theta + Math.PI) % TAU) - Math.PI;
+    if (t <= -Math.PI) t += TAU;
+    if (t > Math.PI) t -= TAU;
+    return t;
+}
+
+/**
+ * Round angle to the nearest N-division on [0, 2π), ties go to the upper (+) side.
+ * Returns a value normalized to (-π, π].
+ */
+export function snapAngle(theta: number, N: number): number {
+    if (!Number.isFinite(theta)) return 0;
+    const n = Math.max(1, Math.floor(Math.abs(N)) || 1);
+    const step = TAU / n;
+    const t0 = normalize0ToTau(theta);
+    // half-up: add step/2 then floor
+    const k = Math.floor((t0 + step / 2) / step);
+    const snapped = k * step;
+    return normalizeMinusPiToPi(snapped);
+}
+
+/**
+ * Snap a point on/near the boundary to the nearest N-division direction and return a unit vector.
+ */
+export function snapBoundaryPoint(p: Vec2, N: number): Vec2 {
+    const theta = boundaryPointToAngle(p);
+    const s = snapAngle(theta, N);
+    return angleToBoundaryPoint(s);
+}
+

--- a/tests/property/snap.properties.test.ts
+++ b/tests/property/snap.properties.test.ts
@@ -1,0 +1,40 @@
+import { test, fc } from "@fast-check/vitest";
+import { snapAngle, snapBoundaryPoint } from "../../src/geom/snap";
+import { angleToBoundaryPoint } from "../../src/geom/unit-disk";
+
+const TAU = 2 * Math.PI;
+
+const angleArb = fc.double({ min: -10 * Math.PI, max: 10 * Math.PI, noNaN: true, noDefaultInfinity: true });
+const nArb = fc.integer({ min: 1, max: 64 });
+
+test.prop([angleArb, nArb])("periodicity: snapAngle(theta+2πk)=snapAngle(theta)", (theta, N) => {
+    const k = fc.sample(fc.integer({ min: -3, max: 3 }), 1)[0] as number;
+    const a = snapAngle(theta, N);
+    const b = snapAngle(theta + k * TAU, N);
+    expect(b).toBeCloseTo(a, 12);
+});
+
+test.prop([angleArb, nArb])("idempotent: snapAngle(snapAngle(theta)) = snapAngle(theta)", (theta, N) => {
+    const a = snapAngle(theta, N);
+    const b = snapAngle(a, N);
+    expect(b).toBeCloseTo(a, 12);
+});
+
+test.prop([angleArb, nArb])("grid membership: result is a multiple of step", (theta, N) => {
+    const step = TAU / N;
+    const a = snapAngle(theta, N);
+    // bring to [0,2π)
+    let t = a % TAU;
+    if (t < 0) t += TAU;
+    const k = Math.round(t / step);
+    expect(t).toBeCloseTo(k * step, 12);
+});
+
+test.prop([angleArb, nArb])("snapBoundaryPoint corresponds to snapping angle", (theta, N) => {
+    const p = angleToBoundaryPoint(theta);
+    const q = snapBoundaryPoint(p, N);
+    const expected = angleToBoundaryPoint(snapAngle(theta, N));
+    expect(q.x).toBeCloseTo(expected.x, 12);
+    expect(q.y).toBeCloseTo(expected.y, 12);
+});
+

--- a/tests/unit/geom/snap.unit.test.ts
+++ b/tests/unit/geom/snap.unit.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { snapAngle, snapBoundaryPoint } from "../../../src/geom/snap";
+
+const TAU = 2 * Math.PI;
+
+describe("snapAngle", () => {
+    it("snaps to canonical axes when N=4", () => {
+        expect(snapAngle(0.01, 4)).toBeCloseTo(0, 12);
+        expect(snapAngle(Math.PI * 0.49, 4)).toBeCloseTo(Math.PI / 2, 12);
+        expect(snapAngle(-Math.PI * 0.49, 4)).toBeCloseTo(-Math.PI / 2, 12);
+        expect(snapAngle(Math.PI * 0.99, 4)).toBeCloseTo(Math.PI, 12);
+    });
+
+    it("tie goes to upper (+) side", () => {
+        const N = 8;
+        const step = TAU / N;
+        const mid = 0.5 * step; // between 0 and step
+        expect(snapAngle(mid, N)).toBeCloseTo(step, 12);
+        // near wrap-around: between (2π-step) and 0 should go to 0 (normalized to 0)
+        const nearWrap = TAU - 0.5 * step;
+        expect(snapAngle(nearWrap, N)).toBeCloseTo(0, 12);
+    });
+});
+
+describe("snapBoundaryPoint", () => {
+    it("returns a unit vector and respects N-grid", () => {
+        const N = 12;
+        const p = { x: 2 * Math.SQRT1_2, y: 2 * Math.SQRT1_2 }; // |p|=2 on 45°
+        const q = snapBoundaryPoint(p, N);
+        expect(Math.hypot(q.x, q.y)).toBeCloseTo(1, 12);
+        // 45° is exact grid for N=8 but not for N=12; just sanity check normalization
+    });
+});
+


### PR DESCRIPTION
Closes #16

Summary
- Implement `src/geom/snap.ts`:
  - `snapAngle(theta,N)`: nearest N-division on [0,2π), ties to upper (+), result normalized to (-π,π]
  - `snapBoundaryPoint(p,N)`: boundary point snapping via angle snapping, returns unit vector
- Tests
  - Unit: representative angles, tie-break behavior, unit length for boundary snap
  - Property (fast-check): periodicity, idempotence, grid membership, boundary<->angle correspondence (seed=424242)

Verification
- `pnpm run test:sandbox`: all tests green (18 files / 45 tests)
- `pnpm typecheck` and `pnpm lint`: pass (acceptance test warnings remain as locked specs)

Notes
- Uses existing Unit Disk utilities for robust angle/point conversions
- No changes to acceptance tests