### PR TITLE
feat(render): canvas DPR scaling and resize util

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "build": "vite build",
         "preview": "vite preview",
         "typecheck": "tsc -p tsconfig.json",
-        "lint": "biome lint .",
+        "lint": "biome check .",
         "format": "biome format --write .",
         "test": "vitest",
         "test:sandbox": "vitest --run --pool=threads --poolOptions.threads.singleThread --no-file-parallelism",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "preview": "vite preview",
         "typecheck": "tsc -p tsconfig.json",
         "lint": "biome check .",
-        "format": "biome format --write .",
+        "format": "biome check --write .",
         "test": "vitest",
         "test:sandbox": "vitest --run --pool=threads --poolOptions.threads.singleThread --no-file-parallelism",
         "coverage": "vitest run --coverage"

--- a/src/geom/circle.ts
+++ b/src/geom/circle.ts
@@ -1,6 +1,6 @@
+import { distance, perp90, safeSqrt } from "./math";
 import type { Circle, IntersectResult, Vec2 } from "./types";
 import { defaultTol, eqTol, tolValue } from "./types";
-import { distance, safeSqrt, perp90 } from "./math";
 
 /**
  * circleCircleIntersection

--- a/src/geom/geodesic.ts
+++ b/src/geom/geodesic.ts
@@ -41,7 +41,12 @@ function normalize(v: Vec2): Vec2 {
  * Degenerate inputs (a≈b, singular system) throw an Error.
  */
 export function geodesicFromBoundary(a: Vec2, b: Vec2): Geodesic {
-    if (!Number.isFinite(a.x) || !Number.isFinite(a.y) || !Number.isFinite(b.x) || !Number.isFinite(b.y)) {
+    if (
+        !Number.isFinite(a.x) ||
+        !Number.isFinite(a.y) ||
+        !Number.isFinite(b.x) ||
+        !Number.isFinite(b.y)
+    ) {
         throw new Error("Non-finite boundary point");
     }
     // Equal endpoints guard

--- a/src/geom/reflect.ts
+++ b/src/geom/reflect.ts
@@ -1,6 +1,6 @@
-import type { Vec2 } from "./types";
-import { invertInCircle } from "./inversion";
 import type { Geodesic } from "./geodesic";
+import { invertInCircle } from "./inversion";
+import type { Vec2 } from "./types";
 
 export type Transform2D = (p: Vec2) => Vec2;
 
@@ -22,4 +22,3 @@ export function reflectAcrossGeodesic(g: Geodesic): Transform2D {
     // circle geodesic: Euclidean inversion in the orthogonal circle
     return (p: Vec2): Vec2 => invertInCircle(p, { c: g.c, r: g.r });
 }
-

--- a/src/geom/snap.ts
+++ b/src/geom/snap.ts
@@ -39,4 +39,3 @@ export function snapBoundaryPoint(p: Vec2, N: number): Vec2 {
     const s = snapAngle(theta, N);
     return angleToBoundaryPoint(s);
 }
-

--- a/src/geom/unit-disk.ts
+++ b/src/geom/unit-disk.ts
@@ -1,4 +1,4 @@
-import type { Vec2, Tolerance } from "./types";
+import type { Tolerance, Vec2 } from "./types";
 import { defaultTol, tolValue } from "./types";
 
 function normalizeAngle(theta: number): number {

--- a/src/render/canvas.ts
+++ b/src/render/canvas.ts
@@ -3,27 +3,28 @@
  * Does not touch styles; callers control CSS layout. Returns the DPR used.
  */
 export function setCanvasDPR(canvas: HTMLCanvasElement, dpr?: number): number {
-  const ratioRaw = typeof dpr === "number" && Number.isFinite(dpr) ? dpr : (globalThis.devicePixelRatio ?? 1);
-  const ratio = Math.max(1, ratioRaw || 1);
+    const ratioRaw =
+        typeof dpr === "number" && Number.isFinite(dpr) ? dpr : (globalThis.devicePixelRatio ?? 1);
+    const ratio = Math.max(1, ratioRaw || 1);
 
-  // Prefer layout box if available; fallback to current attributes.
-  let cssW = canvas.width;
-  let cssH = canvas.height;
-  try {
-    const rect = canvas.getBoundingClientRect?.();
-    if (rect && rect.width > 0 && rect.height > 0) {
-      cssW = rect.width;
-      cssH = rect.height;
+    // Prefer layout box if available; fallback to current attributes.
+    let cssW = canvas.width;
+    let cssH = canvas.height;
+    try {
+        const rect = canvas.getBoundingClientRect?.();
+        if (rect && rect.width > 0 && rect.height > 0) {
+            cssW = rect.width;
+            cssH = rect.height;
+        }
+    } catch {
+        // ignore
     }
-  } catch {
-    // ignore
-  }
 
-  const pxW = Math.max(1, Math.round(cssW * ratio));
-  const pxH = Math.max(1, Math.round(cssH * ratio));
-  canvas.width = pxW;
-  canvas.height = pxH;
-  return ratio;
+    const pxW = Math.max(1, Math.round(cssW * ratio));
+    const pxH = Math.max(1, Math.round(cssH * ratio));
+    canvas.width = pxW;
+    canvas.height = pxH;
+    return ratio;
 }
 
 /**
@@ -31,8 +32,7 @@ export function setCanvasDPR(canvas: HTMLCanvasElement, dpr?: number): number {
  * The callback is invoked on each resize event.
  */
 export function attachResize(_canvas: HTMLCanvasElement, onResize: () => void): () => void {
-  const handler = () => onResize();
-  globalThis.addEventListener("resize", handler);
-  return () => globalThis.removeEventListener("resize", handler);
+    const handler = () => onResize();
+    globalThis.addEventListener("resize", handler);
+    return () => globalThis.removeEventListener("resize", handler);
 }
-

--- a/src/render/canvas.ts
+++ b/src/render/canvas.ts
@@ -1,0 +1,38 @@
+/**
+ * Set the internal bitmap size of a canvas according to CSS size and DPR.
+ * Does not touch styles; callers control CSS layout. Returns the DPR used.
+ */
+export function setCanvasDPR(canvas: HTMLCanvasElement, dpr?: number): number {
+  const ratioRaw = typeof dpr === "number" && Number.isFinite(dpr) ? dpr : (globalThis.devicePixelRatio ?? 1);
+  const ratio = Math.max(1, ratioRaw || 1);
+
+  // Prefer layout box if available; fallback to current attributes.
+  let cssW = canvas.width;
+  let cssH = canvas.height;
+  try {
+    const rect = canvas.getBoundingClientRect?.();
+    if (rect && rect.width > 0 && rect.height > 0) {
+      cssW = rect.width;
+      cssH = rect.height;
+    }
+  } catch {
+    // ignore
+  }
+
+  const pxW = Math.max(1, Math.round(cssW * ratio));
+  const pxH = Math.max(1, Math.round(cssH * ratio));
+  canvas.width = pxW;
+  canvas.height = pxH;
+  return ratio;
+}
+
+/**
+ * Attach a simple window resize listener and return a disposer.
+ * The callback is invoked on each resize event.
+ */
+export function attachResize(_canvas: HTMLCanvasElement, onResize: () => void): () => void {
+  const handler = () => onResize();
+  globalThis.addEventListener("resize", handler);
+  return () => globalThis.removeEventListener("resize", handler);
+}
+

--- a/tests/property/circle.properties.test.ts
+++ b/tests/property/circle.properties.test.ts
@@ -1,4 +1,4 @@
-import { test, fc } from "@fast-check/vitest";
+import { fc, test } from "@fast-check/vitest";
 import { circleCircleIntersection } from "../../src/geom/circle";
 import type { Circle, IntersectResult, Vec2 } from "../../src/geom/types";
 import { sortPts, transformCircle, transformPoint } from "../fixtures/geom";

--- a/tests/property/geodesic.properties.test.ts
+++ b/tests/property/geodesic.properties.test.ts
@@ -1,4 +1,4 @@
-import { test, fc } from "@fast-check/vitest";
+import { fc, test } from "@fast-check/vitest";
 import { geodesicFromBoundary } from "../../src/geom/geodesic";
 import type { Vec2 } from "../../src/geom/types";
 

--- a/tests/property/inversion.properties.test.ts
+++ b/tests/property/inversion.properties.test.ts
@@ -1,5 +1,5 @@
-import { test, fc } from "@fast-check/vitest";
-import { invertUnit, invertInCircle } from "../../src/geom/inversion";
+import { fc, test } from "@fast-check/vitest";
+import { invertInCircle, invertUnit } from "../../src/geom/inversion";
 import type { Circle, Vec2 } from "../../src/geom/types";
 
 const vecArb: fc.Arbitrary<Vec2> = fc.record({
@@ -24,15 +24,12 @@ test.prop([vecArb])("invertUnit is an involution (except near origin)", (p) => {
     return close(back.x, p.x) && close(back.y, p.y);
 });
 
-test.prop([circleArb, vecArb])(
-    "invertInCircle is an involution (except near center)",
-    (C, p) => {
-        const dx = p.x - C.c.x;
-        const dy = p.y - C.c.y;
-        const d2 = dx * dx + dy * dy;
-        fc.pre(d2 > 1e-9);
-        const q = invertInCircle(p, C);
-        const back = invertInCircle(q, C);
-        return close(back.x, p.x) && close(back.y, p.y);
-    },
-);
+test.prop([circleArb, vecArb])("invertInCircle is an involution (except near center)", (C, p) => {
+    const dx = p.x - C.c.x;
+    const dy = p.y - C.c.y;
+    const d2 = dx * dx + dy * dy;
+    fc.pre(d2 > 1e-9);
+    const q = invertInCircle(p, C);
+    const back = invertInCircle(q, C);
+    return close(back.x, p.x) && close(back.y, p.y);
+});

--- a/tests/property/reflect.properties.test.ts
+++ b/tests/property/reflect.properties.test.ts
@@ -1,4 +1,4 @@
-import { test, fc } from "@fast-check/vitest";
+import { fc, test } from "@fast-check/vitest";
 import { geodesicFromBoundary } from "../../src/geom/geodesic";
 import { reflectAcrossGeodesic } from "../../src/geom/reflect";
 import { angleToBoundaryPoint, isOnUnitCircle } from "../../src/geom/unit-disk";
@@ -10,20 +10,23 @@ const pointInDiskArb = fc.record({
     y: fc.double({ min: -0.95, max: 0.95, noNaN: true, noDefaultInfinity: true }),
 });
 
-test.prop([angleArb, pointInDiskArb])("diameter reflection is an involution and boundary-preserving", (theta, p) => {
-    const a = angleToBoundaryPoint(theta);
-    const b = angleToBoundaryPoint(theta + Math.PI);
-    const g = geodesicFromBoundary(a, b);
-    const R = reflectAcrossGeodesic(g);
-    // involution
-    const back = R(R(p));
-    expect(back.x).toBeCloseTo(p.x, 12);
-    expect(back.y).toBeCloseTo(p.y, 12);
-    // boundary maps to boundary
-    const q = angleToBoundaryPoint(theta + 0.123);
-    const rq = R(q);
-    expect(isOnUnitCircle(rq)).toBe(true);
-});
+test.prop([angleArb, pointInDiskArb])(
+    "diameter reflection is an involution and boundary-preserving",
+    (theta, p) => {
+        const a = angleToBoundaryPoint(theta);
+        const b = angleToBoundaryPoint(theta + Math.PI);
+        const g = geodesicFromBoundary(a, b);
+        const R = reflectAcrossGeodesic(g);
+        // involution
+        const back = R(R(p));
+        expect(back.x).toBeCloseTo(p.x, 12);
+        expect(back.y).toBeCloseTo(p.y, 12);
+        // boundary maps to boundary
+        const q = angleToBoundaryPoint(theta + 0.123);
+        const rq = R(q);
+        expect(isOnUnitCircle(rq)).toBe(true);
+    },
+);
 
 test.prop([angleArb, angleArb, pointInDiskArb])(
     "circle reflection (inversion) is an involution and boundary-preserving",

--- a/tests/property/snap.properties.test.ts
+++ b/tests/property/snap.properties.test.ts
@@ -1,10 +1,15 @@
-import { test, fc } from "@fast-check/vitest";
+import { fc, test } from "@fast-check/vitest";
 import { snapAngle, snapBoundaryPoint } from "../../src/geom/snap";
 import { angleToBoundaryPoint } from "../../src/geom/unit-disk";
 
 const TAU = 2 * Math.PI;
 
-const angleArb = fc.double({ min: -10 * Math.PI, max: 10 * Math.PI, noNaN: true, noDefaultInfinity: true });
+const angleArb = fc.double({
+    min: -10 * Math.PI,
+    max: 10 * Math.PI,
+    noNaN: true,
+    noDefaultInfinity: true,
+});
 const nArb = fc.integer({ min: 1, max: 64 });
 
 test.prop([angleArb, nArb])("periodicity: snapAngle(theta+2πk)=snapAngle(theta)", (theta, N) => {
@@ -14,11 +19,14 @@ test.prop([angleArb, nArb])("periodicity: snapAngle(theta+2πk)=snapAngle(theta)
     expect(b).toBeCloseTo(a, 12);
 });
 
-test.prop([angleArb, nArb])("idempotent: snapAngle(snapAngle(theta)) = snapAngle(theta)", (theta, N) => {
-    const a = snapAngle(theta, N);
-    const b = snapAngle(a, N);
-    expect(b).toBeCloseTo(a, 12);
-});
+test.prop([angleArb, nArb])(
+    "idempotent: snapAngle(snapAngle(theta)) = snapAngle(theta)",
+    (theta, N) => {
+        const a = snapAngle(theta, N);
+        const b = snapAngle(a, N);
+        expect(b).toBeCloseTo(a, 12);
+    },
+);
 
 test.prop([angleArb, nArb])("grid membership: result is a multiple of step", (theta, N) => {
     const step = TAU / N;
@@ -37,4 +45,3 @@ test.prop([angleArb, nArb])("snapBoundaryPoint corresponds to snapping angle", (
     expect(q.x).toBeCloseTo(expected.x, 12);
     expect(q.y).toBeCloseTo(expected.y, 12);
 });
-

--- a/tests/property/unit-disk.properties.test.ts
+++ b/tests/property/unit-disk.properties.test.ts
@@ -1,11 +1,11 @@
-import { test, fc } from "@fast-check/vitest";
+import { fc, test } from "@fast-check/vitest";
+import { defaultTol, tolValue } from "../../src/geom/types";
 import {
     angleToBoundaryPoint,
     boundaryPointToAngle,
-    normalizeOnUnitCircle,
     isOnUnitCircle,
+    normalizeOnUnitCircle,
 } from "../../src/geom/unit-disk";
-import { defaultTol, tolValue } from "../../src/geom/types";
 
 const angleArb = fc.double({
     min: -10 * Math.PI,
@@ -88,4 +88,3 @@ test("isOnUnitCircle tolerance behavior", () => {
     expect(isOnUnitCircle(inside)).toBe(true);
     expect(isOnUnitCircle(outside)).toBe(false);
 });
-

--- a/tests/unit/geom/circle.kind-coincident.test.ts
+++ b/tests/unit/geom/circle.kind-coincident.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { circleCircleIntersection } from "../../../src/geom/circle";
 import type { Circle } from "../../../src/geom/types";
 

--- a/tests/unit/geom/circle.kind-concentric.test.ts
+++ b/tests/unit/geom/circle.kind-concentric.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { circleCircleIntersection } from "../../../src/geom/circle";
 import type { Circle } from "../../../src/geom/types";
 

--- a/tests/unit/geom/circle.kind-none.test.ts
+++ b/tests/unit/geom/circle.kind-none.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { circleCircleIntersection } from "../../../src/geom/circle";
 import type { Circle } from "../../../src/geom/types";
 

--- a/tests/unit/geom/circle.kind-tangent.test.ts
+++ b/tests/unit/geom/circle.kind-tangent.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { circleCircleIntersection } from "../../../src/geom/circle";
 import type { Circle } from "../../../src/geom/types";
 

--- a/tests/unit/geom/circle.kind-two.test.ts
+++ b/tests/unit/geom/circle.kind-two.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { circleCircleIntersection } from "../../../src/geom/circle";
 import type { Circle } from "../../../src/geom/types";
 

--- a/tests/unit/geom/circle.point-tangent.test.ts
+++ b/tests/unit/geom/circle.point-tangent.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { circleCircleIntersection } from "../../../src/geom/circle";
 import type { Circle } from "../../../src/geom/types";
 

--- a/tests/unit/geom/circle.points-two.test.ts
+++ b/tests/unit/geom/circle.points-two.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { circleCircleIntersection } from "../../../src/geom/circle";
 import type { Circle } from "../../../src/geom/types";
 

--- a/tests/unit/geom/geodesic.unit.test.ts
+++ b/tests/unit/geom/geodesic.unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { geodesicFromBoundary } from "../../../src/geom/geodesic";
 import type { Vec2 } from "../../../src/geom/types";
 

--- a/tests/unit/geom/inversion.unit.test.ts
+++ b/tests/unit/geom/inversion.unit.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { invertUnit, invertInCircle } from "../../../src/geom/inversion";
+import { describe, expect, it } from "vitest";
+import { invertInCircle, invertUnit } from "../../../src/geom/inversion";
 import type { Circle, Vec2 } from "../../../src/geom/types";
 
 const close = (a: number, b: number, d = 1e-12) => Math.abs(a - b) <= d;

--- a/tests/unit/geom/math.safeSqrt.test.ts
+++ b/tests/unit/geom/math.safeSqrt.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { safeSqrt } from "../../../src/geom/math";
 
 describe("math.safeSqrt", () => {

--- a/tests/unit/geom/reflect.unit.test.ts
+++ b/tests/unit/geom/reflect.unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { geodesicFromBoundary } from "../../../src/geom/geodesic";
 import { reflectAcrossGeodesic } from "../../../src/geom/reflect";
 import { angleToBoundaryPoint } from "../../../src/geom/unit-disk";
@@ -42,4 +42,3 @@ describe("reflectAcrossGeodesic (unit)", () => {
         expect(back.y).toBeCloseTo(p.y, 12);
     });
 });
-

--- a/tests/unit/geom/snap.unit.test.ts
+++ b/tests/unit/geom/snap.unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { snapAngle, snapBoundaryPoint } from "../../../src/geom/snap";
 
 const TAU = 2 * Math.PI;
@@ -31,4 +31,3 @@ describe("snapBoundaryPoint", () => {
         // 45° is exact grid for N=8 but not for N=12; just sanity check normalization
     });
 });
-

--- a/tests/unit/geom/unit-disk.test.ts
+++ b/tests/unit/geom/unit-disk.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from "vitest";
-import { angleToBoundaryPoint, boundaryPointToAngle, isOnUnitCircle, normalizeOnUnitCircle } from "../../../src/geom/unit-disk";
+import { describe, expect, it } from "vitest";
+import {
+    angleToBoundaryPoint,
+    boundaryPointToAngle,
+    isOnUnitCircle,
+    normalizeOnUnitCircle,
+} from "../../../src/geom/unit-disk";
 
 const close = (a: number, b: number, d = 1e-12) => Math.abs(a - b) <= d;
 

--- a/tests/unit/render/canvas.dpr.test.ts
+++ b/tests/unit/render/canvas.dpr.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { setCanvasDPR, attachResize } from "../../../src/render/canvas";
+
+function makeCanvas(cssW: number, cssH: number): HTMLCanvasElement {
+  const cv = document.createElement("canvas");
+  // mock layout size
+  // @ts-expect-error jsdom allows overriding this method
+  cv.getBoundingClientRect = () => ({
+    x: 0,
+    y: 0,
+    top: 0,
+    left: 0,
+    right: cssW,
+    bottom: cssH,
+    width: cssW,
+    height: cssH,
+    toJSON() { return {}; },
+  });
+  return cv;
+}
+
+describe("render/canvas DPR utilities", () => {
+  it("sets internal resolution based on DPR (param) and css size", () => {
+    const cv = makeCanvas(800, 600);
+    const dpr = setCanvasDPR(cv, 2);
+    expect(dpr).toBe(2);
+    expect(cv.width).toBe(1600);
+    expect(cv.height).toBe(1200);
+  });
+
+  it("uses devicePixelRatio when param omitted", () => {
+    const old = globalThis.devicePixelRatio as unknown as number | undefined;
+    // @ts-expect-error allow write
+    globalThis.devicePixelRatio = 1.5;
+    const cv = makeCanvas(400, 300);
+    const dpr = setCanvasDPR(cv);
+    expect(dpr).toBeCloseTo(1.5, 12);
+    expect(cv.width).toBe(600);
+    expect(cv.height).toBe(450);
+    // restore
+    // @ts-expect-error allow write
+    globalThis.devicePixelRatio = old ?? 1;
+  });
+
+  it("attachResize wires and unwires window resize", () => {
+    const cv = makeCanvas(200, 100);
+    const spy = vi.fn();
+    const detach = attachResize(cv, spy);
+    window.dispatchEvent(new Event("resize"));
+    expect(spy).toHaveBeenCalledTimes(1);
+    detach();
+    window.dispatchEvent(new Event("resize"));
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});
+/* @vitest-environment jsdom */

--- a/tests/unit/render/canvas.dpr.test.ts
+++ b/tests/unit/render/canvas.dpr.test.ts
@@ -1,57 +1,59 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { setCanvasDPR, attachResize } from "../../../src/render/canvas";
+import { attachResize, setCanvasDPR } from "../../../src/render/canvas";
 
 function makeCanvas(cssW: number, cssH: number): HTMLCanvasElement {
-  const cv = document.createElement("canvas");
-  // mock layout size
-  // @ts-expect-error jsdom allows overriding this method
-  cv.getBoundingClientRect = () => ({
-    x: 0,
-    y: 0,
-    top: 0,
-    left: 0,
-    right: cssW,
-    bottom: cssH,
-    width: cssW,
-    height: cssH,
-    toJSON() { return {}; },
-  });
-  return cv;
+    const cv = document.createElement("canvas");
+    // mock layout size
+    // @ts-expect-error jsdom allows overriding this method
+    cv.getBoundingClientRect = () => ({
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: cssW,
+        bottom: cssH,
+        width: cssW,
+        height: cssH,
+        toJSON() {
+            return {};
+        },
+    });
+    return cv;
 }
 
 describe("render/canvas DPR utilities", () => {
-  it("sets internal resolution based on DPR (param) and css size", () => {
-    const cv = makeCanvas(800, 600);
-    const dpr = setCanvasDPR(cv, 2);
-    expect(dpr).toBe(2);
-    expect(cv.width).toBe(1600);
-    expect(cv.height).toBe(1200);
-  });
+    it("sets internal resolution based on DPR (param) and css size", () => {
+        const cv = makeCanvas(800, 600);
+        const dpr = setCanvasDPR(cv, 2);
+        expect(dpr).toBe(2);
+        expect(cv.width).toBe(1600);
+        expect(cv.height).toBe(1200);
+    });
 
-  it("uses devicePixelRatio when param omitted", () => {
-    const old = globalThis.devicePixelRatio as unknown as number | undefined;
-    // @ts-expect-error allow write
-    globalThis.devicePixelRatio = 1.5;
-    const cv = makeCanvas(400, 300);
-    const dpr = setCanvasDPR(cv);
-    expect(dpr).toBeCloseTo(1.5, 12);
-    expect(cv.width).toBe(600);
-    expect(cv.height).toBe(450);
-    // restore
-    // @ts-expect-error allow write
-    globalThis.devicePixelRatio = old ?? 1;
-  });
+    it("uses devicePixelRatio when param omitted", () => {
+        const old = globalThis.devicePixelRatio as unknown as number | undefined;
+        // @ts-expect-error allow write
+        globalThis.devicePixelRatio = 1.5;
+        const cv = makeCanvas(400, 300);
+        const dpr = setCanvasDPR(cv);
+        expect(dpr).toBeCloseTo(1.5, 12);
+        expect(cv.width).toBe(600);
+        expect(cv.height).toBe(450);
+        // restore
+        // @ts-expect-error allow write
+        globalThis.devicePixelRatio = old ?? 1;
+    });
 
-  it("attachResize wires and unwires window resize", () => {
-    const cv = makeCanvas(200, 100);
-    const spy = vi.fn();
-    const detach = attachResize(cv, spy);
-    window.dispatchEvent(new Event("resize"));
-    expect(spy).toHaveBeenCalledTimes(1);
-    detach();
-    window.dispatchEvent(new Event("resize"));
-    expect(spy).toHaveBeenCalledTimes(1);
-  });
+    it("attachResize wires and unwires window resize", () => {
+        const cv = makeCanvas(200, 100);
+        const spy = vi.fn();
+        const detach = attachResize(cv, spy);
+        window.dispatchEvent(new Event("resize"));
+        expect(spy).toHaveBeenCalledTimes(1);
+        detach();
+        window.dispatchEvent(new Event("resize"));
+        expect(spy).toHaveBeenCalledTimes(1);
+    });
 });
 /* @vitest-environment jsdom */


### PR DESCRIPTION
Closes #38

Adds:
- src/render/canvas.ts with setCanvasDPR(canvas, dpr?) and attachResize(canvas, cb)
- unit tests (Vitest jsdom) for DPR dimensioning and resize wiring

How to verify
- pnpm run test:sandbox

Notes
- Avoids ctx.getContext() to keep jsdom dependency minimal
