### PR TITLE
feat(render): viewport (world↔screen, compose, invert)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,0 +1,63 @@
+---
+name: "Feature PR"
+about: 新機能・改善の実装 PR テンプレート
+title: "feat: <短く具体的なタイトル>"
+labels: ["type:feature"]
+---
+
+<!--
+記入ルール（要点）
+- PR タイトルは Conventional Commits（feat: / fix: / chore: / refactor: など）
+- 本文先頭に必ず `Closes #<id>`（主役 Issue を 1 つ）。関連は `Refs #<id>`
+- 受け入れ基準（DoD）で誰でも合否判定できるよう具体に（曖昧語NG）
+- コマンドは実行可能な形で記載（pnpm / gh / bash）
+-->
+
+Closes #<id>
+
+## 目的（Why）
+- 背景/課題: {誰が何に困っているかを1–2行で}
+- 目標: {このPRでユーザー/開発者が何をできるようになるか}
+
+## 変更点（What）
+- {主要な変更1}
+- {主要な変更2}
+- {非機能: パフォーマンス/アクセシビリティ/可読性 など}
+
+### 技術詳細（How）
+- 設計/アルゴリズムの要点
+- 代替案の検討（採用しなかった理由があれば）
+
+## スクリーンショット / 動作デモ（任意）
+<!-- スクショ/動画 or Storybook の該当 Story へのリンクを貼る -->
+
+## 受け入れ条件（DoD）
+- [ ] 目的を満たすユーザーストーリーが確認できる
+- [ ] `pnpm typecheck` / `pnpm lint` / `pnpm run test:sandbox` が緑（coverage v8）
+- [ ] 重要分岐のユニット/プロパティテストが追加されている
+- [ ] README/Docs/Storybook（該当時）が更新されている
+- [ ] アクセシビリティ: ラベル/フォーカス/キーボードが機能し重大違反なし
+
+## 確認手順（Reviewer 向け）
+```bash
+pnpm i
+pnpm lint && pnpm typecheck && pnpm run test:sandbox
+# 開発サーバ（必要時）
+pnpm dev
+```
+
+## リスクとロールバック
+- 影響範囲: {モジュール/機能名}
+- リスク/懸念: {既知の課題・トレードオフ}
+- ロールバック指針: {切り戻し手順 or フラグ無効化手段}
+
+## Out of Scope（別PR）
+- {今回やらないこと}
+
+## 関連 Issue / PR
+- Refs #<id>
+- Blocked by #<id> / Blocks #<id>
+
+## 追加メモ（任意）
+- プロジェクト連携: 必要なら Project の Priority/Order 更新
+- リリースノート案: {ユーザー向け1行}

--- a/README.md
+++ b/README.md
@@ -24,11 +24,37 @@ pnpm test           # coverage provider: v8
 ## 最低限の方針
 - TDD で進める。受け入れテスト（`tests/acceptance/**`）は人間が作成しロック。エージェントは変更不可。
 - 幾何の最初の対象は circle×circle。返却規約（kind/points）と「2点は x→y 昇順」を厳守。
-- 1 タスク = 1 コミット。pre-commit で lint/format/test を通す。
+- 1 タスク = 1 コミット。（実装ステップごとに小さくコミット）pre-commit で lint/format/test を通す。
 
 ### 用語/型の統一
 - ベクトル型は `Vec2` を公開名として採用（旧 `Vec` は廃止）。
 - 主な幾何モジュール: `geom/circle.ts`（円×円交点）, `geom/geodesic.ts`（境界2点→直交円/直径）, `geom/inversion.ts`（円反転）, `geom/unit-disk.ts`（単位円ユーティリティ）。
+
+## Render Backend Portability（Canvas 2D / SVG / WebGL/GLSL）
+
+本PoCは描画バックエンドを差し替え可能にするため、以下の層に分離します。
+
+- レイヤ構成
+  - 幾何（world空間）: ジオメトリ/数学（geodesic 等）。
+  - ビューポート（world→screen）: 等方スケール+平行移動の純粋変換。
+  - プリミティブSpec（screen空間）: 描画に必要な最小の数値仕様（API非依存）。
+    - 例: CircleSpec `{ cx, cy, r }`、LineSpec `{ x1, y1, x2, y2 }`（拡張可能）。
+  - バックエンドアダプタ: Specを消費してCanvas/SVG/WebGLへ描画する層。
+
+- 不変条件/指針
+  - Core/SpecはCanvas/WebGLの直接呼び出しを含めない（数値契約のみ）。
+  - SpecはDPR/ビューポート適用後のscreen座標を返し、スタイル（色/線幅/AA）は含めない。
+  - 各SpecからAABBを導出してカリング/Invalidationに利用（GPU Readbackに依存しない）。
+  - 描画順は安定ソートで管理し、バックエンド差異でも結果の一貫性を確保。
+  - DPRは事前に解決（`src/render/canvas.ts`）。
+
+- WebGL/GLSL（将来）
+  - Viewportはuniformで渡す。Specを頂点/インスタンスに展開し、ライン/三角形で表現。
+  - ジオデシックは距離場シェーダやストロークのどちらでも実現可能（性能/品質で選択）。
+  - scissor/clipやAABBで部分描画を行い、フレームバッファのReadbackを避ける。
+  - ドローコールをプログラム/状態でバッチしつつ、必要な順序を保持。
+
+この構造により、GLSL への移行は「Specを解釈するWebGLアダプタの追加」で完結し、幾何やビューポートのコードは不変のまま差し替え可能です。
 
 ## リンク
 - docs/ROADMAP.md（中長期の方向性メモ）

--- a/ops/ai/playbooks/dev_flow.md
+++ b/ops/ai/playbooks/dev_flow.md
@@ -77,7 +77,8 @@ pnpm i
 3) **TDD で実装**  
    - 最小の失敗テスト → 実装 → 緑化  
    - 小さくコミット（Conventional Commits、`Refs #<id>`）  
-   - `pnpm biome:check && pnpm typecheck && pnpm test` を都度通す  
+   - `pnpm run lint && pnpm typecheck && pnpm run test:sandbox` を都度通す
+   - `pnpm run format` で都度フォーマット（import 並び替え/整形を含む）
 4) **PR 作成**（Draft 可）  
    - `gh pr create -B main -H $(git branch --show-current) -t "<短いタイトル>" -b $'Closes #<id>
 

--- a/src/render/invalidation.ts
+++ b/src/render/invalidation.ts
@@ -1,95 +1,98 @@
 export type Rect = { x: number; y: number; w: number; h: number };
 
 function normRect(r: Rect): Rect {
-  const x2 = r.x + r.w;
-  const y2 = r.y + r.h;
-  const x = Math.min(r.x, x2);
-  const y = Math.min(r.y, y2);
-  const w = Math.abs(r.w);
-  const h = Math.abs(r.h);
-  return { x, y, w, h };
+    const x2 = r.x + r.w;
+    const y2 = r.y + r.h;
+    const x = Math.min(r.x, x2);
+    const y = Math.min(r.y, y2);
+    const w = Math.abs(r.w);
+    const h = Math.abs(r.h);
+    return { x, y, w, h };
 }
 
 export function intersects(a: Rect, b: Rect): boolean {
-  a = normRect(a);
-  b = normRect(b);
-  return a.x <= b.x + b.w && b.x <= a.x + a.w && a.y <= b.y + b.h && b.y <= a.y + a.h;
+    a = normRect(a);
+    b = normRect(b);
+    return a.x <= b.x + b.w && b.x <= a.x + a.w && a.y <= b.y + b.h && b.y <= a.y + a.h;
 }
 
 export function adjacent(a: Rect, b: Rect): boolean {
-  // share edge horizontally or vertically and overlapping on the other axis
-  a = normRect(a);
-  b = normRect(b);
-  const horizTouch = a.y < b.y + b.h && b.y < a.y + a.h && (a.x + a.w === b.x || b.x + b.w === a.x);
-  const vertTouch = a.x < b.x + b.w && b.x < a.x + a.w && (a.y + a.h === b.y || b.y + b.h === a.y);
-  return horizTouch || vertTouch;
+    // share edge horizontally or vertically and overlapping on the other axis
+    a = normRect(a);
+    b = normRect(b);
+    const horizTouch =
+        a.y < b.y + b.h && b.y < a.y + a.h && (a.x + a.w === b.x || b.x + b.w === a.x);
+    const vertTouch =
+        a.x < b.x + b.w && b.x < a.x + a.w && (a.y + a.h === b.y || b.y + b.h === a.y);
+    return horizTouch || vertTouch;
 }
 
 export function union(a: Rect, b: Rect): Rect {
-  a = normRect(a);
-  b = normRect(b);
-  const x1 = Math.min(a.x, b.x);
-  const y1 = Math.min(a.y, b.y);
-  const x2 = Math.max(a.x + a.w, b.x + b.w);
-  const y2 = Math.max(a.y + a.h, b.y + b.h);
-  return { x: x1, y: y1, w: x2 - x1, h: y2 - y1 };
+    a = normRect(a);
+    b = normRect(b);
+    const x1 = Math.min(a.x, b.x);
+    const y1 = Math.min(a.y, b.y);
+    const x2 = Math.max(a.x + a.w, b.x + b.w);
+    const y2 = Math.max(a.y + a.h, b.y + b.h);
+    return { x: x1, y: y1, w: x2 - x1, h: y2 - y1 };
 }
 
 function mergeRects(rects: Rect[]): Rect[] {
-  // naive O(n^2) merge of intersecting/adjacent rectangles
-  const rs = rects.map(normRect);
-  let changed = true;
-  while (changed) {
-    changed = false;
-    for (let i = 0; i < rs.length && !changed; i++) {
-      for (let j = i + 1; j < rs.length && !changed; j++) {
-        const a = rs[i];
-        const b = rs[j];
-        if (intersects(a, b) || adjacent(a, b)) {
-          const u = union(a, b);
-          rs.splice(j, 1);
-          rs[i] = u;
-          changed = true;
+    // naive O(n^2) merge of intersecting/adjacent rectangles
+    const rs = rects.map(normRect);
+    let changed = true;
+    while (changed) {
+        changed = false;
+        for (let i = 0; i < rs.length && !changed; i++) {
+            for (let j = i + 1; j < rs.length && !changed; j++) {
+                const a = rs[i];
+                const b = rs[j];
+                if (intersects(a, b) || adjacent(a, b)) {
+                    const u = union(a, b);
+                    rs.splice(j, 1);
+                    rs[i] = u;
+                    changed = true;
+                }
+            }
         }
-      }
     }
-  }
-  return rs;
+    return rs;
 }
 
 export class InvalidationScheduler {
-  private pending: Rect[] = [];
-  private rafId: number | null = null;
+    private pending: Rect[] = [];
+    private rafId: number | null = null;
 
-  constructor(private onFlush: (rects: Rect[]) => void) {}
+    constructor(private onFlush: (rects: Rect[]) => void) {}
 
-  invalidate(r: Rect): void {
-    this.pending.push(normRect(r));
-    if (this.rafId === null) {
-      const raf = (globalThis.requestAnimationFrame ?? ((cb: FrameRequestCallback) => setTimeout(() => cb(performance.now()), 16) as unknown as number)).bind(
-        globalThis,
-      );
-      this.rafId = raf(() => this.flush());
+    invalidate(r: Rect): void {
+        this.pending.push(normRect(r));
+        if (this.rafId === null) {
+            const raf = (
+                globalThis.requestAnimationFrame ??
+                ((cb: FrameRequestCallback) =>
+                    setTimeout(() => cb(performance.now()), 16) as unknown as number)
+            ).bind(globalThis);
+            this.rafId = raf(() => this.flush());
+        }
     }
-  }
 
-  flush(): void {
-    if (this.rafId !== null && globalThis.cancelAnimationFrame) {
-      // not strictly necessary; frame just fired
-      this.rafId = null;
+    flush(): void {
+        if (this.rafId !== null && globalThis.cancelAnimationFrame) {
+            // not strictly necessary; frame just fired
+            this.rafId = null;
+        }
+        if (this.pending.length === 0) return;
+        const merged = mergeRects(this.pending);
+        this.pending = [];
+        this.onFlush(merged);
     }
-    if (this.pending.length === 0) return;
-    const merged = mergeRects(this.pending);
-    this.pending = [];
-    this.onFlush(merged);
-  }
 
-  dispose(): void {
-    if (this.rafId !== null && globalThis.cancelAnimationFrame) {
-      globalThis.cancelAnimationFrame(this.rafId);
+    dispose(): void {
+        if (this.rafId !== null && globalThis.cancelAnimationFrame) {
+            globalThis.cancelAnimationFrame(this.rafId);
+        }
+        this.rafId = null;
+        this.pending = [];
     }
-    this.rafId = null;
-    this.pending = [];
-  }
 }
-

--- a/src/render/invalidation.ts
+++ b/src/render/invalidation.ts
@@ -1,0 +1,95 @@
+export type Rect = { x: number; y: number; w: number; h: number };
+
+function normRect(r: Rect): Rect {
+  const x2 = r.x + r.w;
+  const y2 = r.y + r.h;
+  const x = Math.min(r.x, x2);
+  const y = Math.min(r.y, y2);
+  const w = Math.abs(r.w);
+  const h = Math.abs(r.h);
+  return { x, y, w, h };
+}
+
+export function intersects(a: Rect, b: Rect): boolean {
+  a = normRect(a);
+  b = normRect(b);
+  return a.x <= b.x + b.w && b.x <= a.x + a.w && a.y <= b.y + b.h && b.y <= a.y + a.h;
+}
+
+export function adjacent(a: Rect, b: Rect): boolean {
+  // share edge horizontally or vertically and overlapping on the other axis
+  a = normRect(a);
+  b = normRect(b);
+  const horizTouch = a.y < b.y + b.h && b.y < a.y + a.h && (a.x + a.w === b.x || b.x + b.w === a.x);
+  const vertTouch = a.x < b.x + b.w && b.x < a.x + a.w && (a.y + a.h === b.y || b.y + b.h === a.y);
+  return horizTouch || vertTouch;
+}
+
+export function union(a: Rect, b: Rect): Rect {
+  a = normRect(a);
+  b = normRect(b);
+  const x1 = Math.min(a.x, b.x);
+  const y1 = Math.min(a.y, b.y);
+  const x2 = Math.max(a.x + a.w, b.x + b.w);
+  const y2 = Math.max(a.y + a.h, b.y + b.h);
+  return { x: x1, y: y1, w: x2 - x1, h: y2 - y1 };
+}
+
+function mergeRects(rects: Rect[]): Rect[] {
+  // naive O(n^2) merge of intersecting/adjacent rectangles
+  const rs = rects.map(normRect);
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (let i = 0; i < rs.length && !changed; i++) {
+      for (let j = i + 1; j < rs.length && !changed; j++) {
+        const a = rs[i];
+        const b = rs[j];
+        if (intersects(a, b) || adjacent(a, b)) {
+          const u = union(a, b);
+          rs.splice(j, 1);
+          rs[i] = u;
+          changed = true;
+        }
+      }
+    }
+  }
+  return rs;
+}
+
+export class InvalidationScheduler {
+  private pending: Rect[] = [];
+  private rafId: number | null = null;
+
+  constructor(private onFlush: (rects: Rect[]) => void) {}
+
+  invalidate(r: Rect): void {
+    this.pending.push(normRect(r));
+    if (this.rafId === null) {
+      const raf = (globalThis.requestAnimationFrame ?? ((cb: FrameRequestCallback) => setTimeout(() => cb(performance.now()), 16) as unknown as number)).bind(
+        globalThis,
+      );
+      this.rafId = raf(() => this.flush());
+    }
+  }
+
+  flush(): void {
+    if (this.rafId !== null && globalThis.cancelAnimationFrame) {
+      // not strictly necessary; frame just fired
+      this.rafId = null;
+    }
+    if (this.pending.length === 0) return;
+    const merged = mergeRects(this.pending);
+    this.pending = [];
+    this.onFlush(merged);
+  }
+
+  dispose(): void {
+    if (this.rafId !== null && globalThis.cancelAnimationFrame) {
+      globalThis.cancelAnimationFrame(this.rafId);
+    }
+    this.rafId = null;
+    this.pending = [];
+  }
+}
+

--- a/src/render/primitives.ts
+++ b/src/render/primitives.ts
@@ -1,0 +1,25 @@
+import type { Geodesic } from "../geom/geodesic";
+import type { Viewport } from "./viewport";
+import { worldToScreen } from "./viewport";
+
+export type CircleSpec = { cx: number; cy: number; r: number };
+export type LineSpec = { x1: number; y1: number; x2: number; y2: number };
+
+export function unitDiskSpec(vp: Viewport): CircleSpec {
+  const c = worldToScreen(vp, { x: 0, y: 0 });
+  const r = Math.abs(vp.scale || 1) * 1;
+  return { cx: c.x, cy: c.y, r };
+}
+
+export function geodesicSpec(geo: Geodesic, vp: Viewport): CircleSpec | LineSpec {
+  if (geo.kind === "circle") {
+    const c = worldToScreen(vp, geo.c);
+    const r = Math.abs(vp.scale || 1) * geo.r;
+    return { cx: c.x, cy: c.y, r };
+  }
+  // diameter through origin in direction dir (unit), draw as a line through screen center
+  const a = worldToScreen(vp, { x: -geo.dir.x, y: -geo.dir.y });
+  const b = worldToScreen(vp, { x: geo.dir.x, y: geo.dir.y });
+  return { x1: a.x, y1: a.y, x2: b.x, y2: b.y };
+}
+

--- a/src/render/primitives.ts
+++ b/src/render/primitives.ts
@@ -6,20 +6,19 @@ export type CircleSpec = { cx: number; cy: number; r: number };
 export type LineSpec = { x1: number; y1: number; x2: number; y2: number };
 
 export function unitDiskSpec(vp: Viewport): CircleSpec {
-  const c = worldToScreen(vp, { x: 0, y: 0 });
-  const r = Math.abs(vp.scale || 1) * 1;
-  return { cx: c.x, cy: c.y, r };
+    const c = worldToScreen(vp, { x: 0, y: 0 });
+    const r = Math.abs(vp.scale || 1) * 1;
+    return { cx: c.x, cy: c.y, r };
 }
 
 export function geodesicSpec(geo: Geodesic, vp: Viewport): CircleSpec | LineSpec {
-  if (geo.kind === "circle") {
-    const c = worldToScreen(vp, geo.c);
-    const r = Math.abs(vp.scale || 1) * geo.r;
-    return { cx: c.x, cy: c.y, r };
-  }
-  // diameter through origin in direction dir (unit), draw as a line through screen center
-  const a = worldToScreen(vp, { x: -geo.dir.x, y: -geo.dir.y });
-  const b = worldToScreen(vp, { x: geo.dir.x, y: geo.dir.y });
-  return { x1: a.x, y1: a.y, x2: b.x, y2: b.y };
+    if (geo.kind === "circle") {
+        const c = worldToScreen(vp, geo.c);
+        const r = Math.abs(vp.scale || 1) * geo.r;
+        return { cx: c.x, cy: c.y, r };
+    }
+    // diameter through origin in direction dir (unit), draw as a line through screen center
+    const a = worldToScreen(vp, { x: -geo.dir.x, y: -geo.dir.y });
+    const b = worldToScreen(vp, { x: geo.dir.x, y: geo.dir.y });
+    return { x1: a.x, y1: a.y, x2: b.x, y2: b.y };
 }
-

--- a/src/render/viewport.ts
+++ b/src/render/viewport.ts
@@ -1,44 +1,43 @@
 export type Viewport = {
-  scale: number; // pixels per world unit
-  tx: number; // translation in pixels (x)
-  ty: number; // translation in pixels (y)
+    scale: number; // pixels per world unit
+    tx: number; // translation in pixels (x)
+    ty: number; // translation in pixels (y)
 };
 
 export const identity: Viewport = { scale: 1, tx: 0, ty: 0 };
 
 export function worldToScreen(vp: Viewport, p: { x: number; y: number }): { x: number; y: number } {
-  const s = Math.max(0, Number.isFinite(vp.scale) ? vp.scale : 1);
-  const tx = Number.isFinite(vp.tx) ? vp.tx : 0;
-  const ty = Number.isFinite(vp.ty) ? vp.ty : 0;
-  return { x: p.x * s + tx, y: p.y * s + ty };
+    const s = Math.max(0, Number.isFinite(vp.scale) ? vp.scale : 1);
+    const tx = Number.isFinite(vp.tx) ? vp.tx : 0;
+    const ty = Number.isFinite(vp.ty) ? vp.ty : 0;
+    return { x: p.x * s + tx, y: p.y * s + ty };
 }
 
 export function screenToWorld(vp: Viewport, s: { x: number; y: number }): { x: number; y: number } {
-  const sc = Number.isFinite(vp.scale) && vp.scale !== 0 ? vp.scale : 1;
-  const tx = Number.isFinite(vp.tx) ? vp.tx : 0;
-  const ty = Number.isFinite(vp.ty) ? vp.ty : 0;
-  return { x: (s.x - tx) / sc, y: (s.y - ty) / sc };
+    const sc = Number.isFinite(vp.scale) && vp.scale !== 0 ? vp.scale : 1;
+    const tx = Number.isFinite(vp.tx) ? vp.tx : 0;
+    const ty = Number.isFinite(vp.ty) ? vp.ty : 0;
+    return { x: (s.x - tx) / sc, y: (s.y - ty) / sc };
 }
 
 /** Compose transforms: apply a then b (world -> a -> b). */
 export function compose(b: Viewport, a: Viewport): Viewport {
-  // b(a(p)) = (a.scale * p + a.t) * b.scale + b.t = (b.scale * a.scale) p + (b.scale * a.t + b.t)
-  const scale = (b.scale || 1) * (a.scale || 1);
-  return {
-    scale,
-    tx: (b.scale || 1) * a.tx + b.tx,
-    ty: (b.scale || 1) * a.ty + b.ty,
-  };
+    // b(a(p)) = (a.scale * p + a.t) * b.scale + b.t = (b.scale * a.scale) p + (b.scale * a.t + b.t)
+    const scale = (b.scale || 1) * (a.scale || 1);
+    return {
+        scale,
+        tx: (b.scale || 1) * a.tx + b.tx,
+        ty: (b.scale || 1) * a.ty + b.ty,
+    };
 }
 
 /** Inverse transform such that worldToScreen(invert(vp), screen) = world. */
 export function invert(vp: Viewport): Viewport {
-  const s = Number.isFinite(vp.scale) && vp.scale !== 0 ? vp.scale : 1;
-  const invS = 1 / s;
-  return {
-    scale: invS,
-    tx: -vp.tx * invS,
-    ty: -vp.ty * invS,
-  };
+    const s = Number.isFinite(vp.scale) && vp.scale !== 0 ? vp.scale : 1;
+    const invS = 1 / s;
+    return {
+        scale: invS,
+        tx: -vp.tx * invS,
+        ty: -vp.ty * invS,
+    };
 }
-

--- a/src/render/viewport.ts
+++ b/src/render/viewport.ts
@@ -1,0 +1,44 @@
+export type Viewport = {
+  scale: number; // pixels per world unit
+  tx: number; // translation in pixels (x)
+  ty: number; // translation in pixels (y)
+};
+
+export const identity: Viewport = { scale: 1, tx: 0, ty: 0 };
+
+export function worldToScreen(vp: Viewport, p: { x: number; y: number }): { x: number; y: number } {
+  const s = Math.max(0, Number.isFinite(vp.scale) ? vp.scale : 1);
+  const tx = Number.isFinite(vp.tx) ? vp.tx : 0;
+  const ty = Number.isFinite(vp.ty) ? vp.ty : 0;
+  return { x: p.x * s + tx, y: p.y * s + ty };
+}
+
+export function screenToWorld(vp: Viewport, s: { x: number; y: number }): { x: number; y: number } {
+  const sc = Number.isFinite(vp.scale) && vp.scale !== 0 ? vp.scale : 1;
+  const tx = Number.isFinite(vp.tx) ? vp.tx : 0;
+  const ty = Number.isFinite(vp.ty) ? vp.ty : 0;
+  return { x: (s.x - tx) / sc, y: (s.y - ty) / sc };
+}
+
+/** Compose transforms: apply a then b (world -> a -> b). */
+export function compose(b: Viewport, a: Viewport): Viewport {
+  // b(a(p)) = (a.scale * p + a.t) * b.scale + b.t = (b.scale * a.scale) p + (b.scale * a.t + b.t)
+  const scale = (b.scale || 1) * (a.scale || 1);
+  return {
+    scale,
+    tx: (b.scale || 1) * a.tx + b.tx,
+    ty: (b.scale || 1) * a.ty + b.ty,
+  };
+}
+
+/** Inverse transform such that worldToScreen(invert(vp), screen) = world. */
+export function invert(vp: Viewport): Viewport {
+  const s = Number.isFinite(vp.scale) && vp.scale !== 0 ? vp.scale : 1;
+  const invS = 1 / s;
+  return {
+    scale: invS,
+    tx: -vp.tx * invS,
+    ty: -vp.ty * invS,
+  };
+}
+

--- a/tests/unit/render/invalidation.test.ts
+++ b/tests/unit/render/invalidation.test.ts
@@ -1,0 +1,36 @@
+/* @vitest-environment jsdom */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { InvalidationScheduler, type Rect, adjacent, intersects, union } from "../../../src/render/invalidation";
+
+const r = (x: number, y: number, w: number, h: number): Rect => ({ x, y, w, h });
+
+describe("render/invalidation", () => {
+  it("intersects and adjacent detection", () => {
+    expect(intersects(r(0, 0, 10, 10), r(5, 5, 10, 10))).toBe(true);
+    expect(intersects(r(0, 0, 10, 10), r(11, 0, 5, 5))).toBe(false);
+    expect(adjacent(r(0, 0, 10, 10), r(10, 2, 5, 4))).toBe(true);
+    expect(adjacent(r(0, 0, 10, 10), r(0, 10, 4, 5))).toBe(true);
+  });
+
+  it("union merges to bounding rect", () => {
+    const u = union(r(0, 0, 10, 10), r(8, -2, 10, 4));
+    expect(u).toEqual({ x: 0, y: -2, w: 18, h: 12 });
+  });
+
+  it("coalesces multiple invalidates into one RAF frame", async () => {
+    vi.useFakeTimers();
+    const calls: Rect[][] = [];
+    const sched = new InvalidationScheduler((rects) => calls.push(rects));
+    sched.invalidate({ x: 0, y: 0, w: 10, h: 10 });
+    sched.invalidate({ x: 8, y: 0, w: 10, h: 10 }); // overlaps -> merge
+    // advance a frame
+    // requestAnimationFrame fallback uses setTimeout(16)
+    vi.advanceTimersByTime(20);
+    expect(calls.length).toBe(1);
+    expect(calls[0].length).toBe(1);
+    expect(calls[0][0]).toEqual({ x: 0, y: 0, w: 18, h: 10 });
+    vi.useRealTimers();
+  });
+});
+

--- a/tests/unit/render/invalidation.test.ts
+++ b/tests/unit/render/invalidation.test.ts
@@ -1,5 +1,5 @@
 /* @vitest-environment jsdom */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
     adjacent,

--- a/tests/unit/render/invalidation.test.ts
+++ b/tests/unit/render/invalidation.test.ts
@@ -1,36 +1,41 @@
 /* @vitest-environment jsdom */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { InvalidationScheduler, type Rect, adjacent, intersects, union } from "../../../src/render/invalidation";
+import {
+    adjacent,
+    InvalidationScheduler,
+    intersects,
+    type Rect,
+    union,
+} from "../../../src/render/invalidation";
 
 const r = (x: number, y: number, w: number, h: number): Rect => ({ x, y, w, h });
 
 describe("render/invalidation", () => {
-  it("intersects and adjacent detection", () => {
-    expect(intersects(r(0, 0, 10, 10), r(5, 5, 10, 10))).toBe(true);
-    expect(intersects(r(0, 0, 10, 10), r(11, 0, 5, 5))).toBe(false);
-    expect(adjacent(r(0, 0, 10, 10), r(10, 2, 5, 4))).toBe(true);
-    expect(adjacent(r(0, 0, 10, 10), r(0, 10, 4, 5))).toBe(true);
-  });
+    it("intersects and adjacent detection", () => {
+        expect(intersects(r(0, 0, 10, 10), r(5, 5, 10, 10))).toBe(true);
+        expect(intersects(r(0, 0, 10, 10), r(11, 0, 5, 5))).toBe(false);
+        expect(adjacent(r(0, 0, 10, 10), r(10, 2, 5, 4))).toBe(true);
+        expect(adjacent(r(0, 0, 10, 10), r(0, 10, 4, 5))).toBe(true);
+    });
 
-  it("union merges to bounding rect", () => {
-    const u = union(r(0, 0, 10, 10), r(8, -2, 10, 4));
-    expect(u).toEqual({ x: 0, y: -2, w: 18, h: 12 });
-  });
+    it("union merges to bounding rect", () => {
+        const u = union(r(0, 0, 10, 10), r(8, -2, 10, 4));
+        expect(u).toEqual({ x: 0, y: -2, w: 18, h: 12 });
+    });
 
-  it("coalesces multiple invalidates into one RAF frame", async () => {
-    vi.useFakeTimers();
-    const calls: Rect[][] = [];
-    const sched = new InvalidationScheduler((rects) => calls.push(rects));
-    sched.invalidate({ x: 0, y: 0, w: 10, h: 10 });
-    sched.invalidate({ x: 8, y: 0, w: 10, h: 10 }); // overlaps -> merge
-    // advance a frame
-    // requestAnimationFrame fallback uses setTimeout(16)
-    vi.advanceTimersByTime(20);
-    expect(calls.length).toBe(1);
-    expect(calls[0].length).toBe(1);
-    expect(calls[0][0]).toEqual({ x: 0, y: 0, w: 18, h: 10 });
-    vi.useRealTimers();
-  });
+    it("coalesces multiple invalidates into one RAF frame", async () => {
+        vi.useFakeTimers();
+        const calls: Rect[][] = [];
+        const sched = new InvalidationScheduler((rects) => calls.push(rects));
+        sched.invalidate({ x: 0, y: 0, w: 10, h: 10 });
+        sched.invalidate({ x: 8, y: 0, w: 10, h: 10 }); // overlaps -> merge
+        // advance a frame
+        // requestAnimationFrame fallback uses setTimeout(16)
+        vi.advanceTimersByTime(20);
+        expect(calls.length).toBe(1);
+        expect(calls[0].length).toBe(1);
+        expect(calls[0][0]).toEqual({ x: 0, y: 0, w: 18, h: 10 });
+        vi.useRealTimers();
+    });
 });
-

--- a/tests/unit/render/primitives.test.ts
+++ b/tests/unit/render/primitives.test.ts
@@ -1,0 +1,49 @@
+/* @vitest-environment jsdom */
+import { describe, expect, it } from "vitest";
+
+import { geodesicFromBoundary, type Geodesic } from "../../../src/geom/geodesic";
+import { angleToBoundaryPoint } from "../../../src/geom/unit-disk";
+import { geodesicSpec, unitDiskSpec } from "../../../src/render/primitives";
+import { identity, type Viewport } from "../../../src/render/viewport";
+
+const close = (a: number, b: number, d = 1e-12) => Math.abs(a - b) <= d;
+
+describe("render/primitives specs", () => {
+  it("unitDiskSpec maps to screen with scale", () => {
+    const vp: Viewport = { scale: 200, tx: 320, ty: 240 };
+    const c = unitDiskSpec(vp);
+    expect(close(c.cx, 320)).toBe(true);
+    expect(close(c.cy, 240)).toBe(true);
+    expect(close(c.r, 200)).toBe(true);
+  });
+
+  it("geodesicSpec(circle) produces screen circle", () => {
+    const a = angleToBoundaryPoint(0);
+    const b = angleToBoundaryPoint(Math.PI / 3);
+    const g: Geodesic = geodesicFromBoundary(a, b);
+    expect(g.kind).toBe("circle");
+    const vp = identity;
+    const s = geodesicSpec(g, vp);
+    if ("r" in s) {
+      // radius equals world radius when scale=1
+      expect(s.r).toBeCloseTo(g.r, 12);
+    } else {
+      throw new Error("expected circle spec");
+    }
+  });
+
+  it("geodesicSpec(diameter) produces a line through ±dir", () => {
+    const a = angleToBoundaryPoint(0);
+    const b = angleToBoundaryPoint(Math.PI);
+    const g: Geodesic = geodesicFromBoundary(a, b);
+    expect(g.kind).toBe("diameter");
+    const s = geodesicSpec(g, identity);
+    if ("x1" in s) {
+      expect(close(s.y1, s.y2)).toBe(true); // horizontal line
+      expect(close(s.x1, -1) && close(s.x2, 1)).toBe(true);
+    } else {
+      throw new Error("expected line spec");
+    }
+  });
+});
+

--- a/tests/unit/render/primitives.test.ts
+++ b/tests/unit/render/primitives.test.ts
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 import { describe, expect, it } from "vitest";
 
-import { geodesicFromBoundary, type Geodesic } from "../../../src/geom/geodesic";
+import { type Geodesic, geodesicFromBoundary } from "../../../src/geom/geodesic";
 import { angleToBoundaryPoint } from "../../../src/geom/unit-disk";
 import { geodesicSpec, unitDiskSpec } from "../../../src/render/primitives";
 import { identity, type Viewport } from "../../../src/render/viewport";
@@ -9,41 +9,40 @@ import { identity, type Viewport } from "../../../src/render/viewport";
 const close = (a: number, b: number, d = 1e-12) => Math.abs(a - b) <= d;
 
 describe("render/primitives specs", () => {
-  it("unitDiskSpec maps to screen with scale", () => {
-    const vp: Viewport = { scale: 200, tx: 320, ty: 240 };
-    const c = unitDiskSpec(vp);
-    expect(close(c.cx, 320)).toBe(true);
-    expect(close(c.cy, 240)).toBe(true);
-    expect(close(c.r, 200)).toBe(true);
-  });
+    it("unitDiskSpec maps to screen with scale", () => {
+        const vp: Viewport = { scale: 200, tx: 320, ty: 240 };
+        const c = unitDiskSpec(vp);
+        expect(close(c.cx, 320)).toBe(true);
+        expect(close(c.cy, 240)).toBe(true);
+        expect(close(c.r, 200)).toBe(true);
+    });
 
-  it("geodesicSpec(circle) produces screen circle", () => {
-    const a = angleToBoundaryPoint(0);
-    const b = angleToBoundaryPoint(Math.PI / 3);
-    const g: Geodesic = geodesicFromBoundary(a, b);
-    expect(g.kind).toBe("circle");
-    const vp = identity;
-    const s = geodesicSpec(g, vp);
-    if ("r" in s) {
-      // radius equals world radius when scale=1
-      expect(s.r).toBeCloseTo(g.r, 12);
-    } else {
-      throw new Error("expected circle spec");
-    }
-  });
+    it("geodesicSpec(circle) produces screen circle", () => {
+        const a = angleToBoundaryPoint(0);
+        const b = angleToBoundaryPoint(Math.PI / 3);
+        const g: Geodesic = geodesicFromBoundary(a, b);
+        expect(g.kind).toBe("circle");
+        const vp = identity;
+        const s = geodesicSpec(g, vp);
+        if ("r" in s) {
+            // radius equals world radius when scale=1
+            expect(s.r).toBeCloseTo(g.r, 12);
+        } else {
+            throw new Error("expected circle spec");
+        }
+    });
 
-  it("geodesicSpec(diameter) produces a line through ±dir", () => {
-    const a = angleToBoundaryPoint(0);
-    const b = angleToBoundaryPoint(Math.PI);
-    const g: Geodesic = geodesicFromBoundary(a, b);
-    expect(g.kind).toBe("diameter");
-    const s = geodesicSpec(g, identity);
-    if ("x1" in s) {
-      expect(close(s.y1, s.y2)).toBe(true); // horizontal line
-      expect(close(s.x1, -1) && close(s.x2, 1)).toBe(true);
-    } else {
-      throw new Error("expected line spec");
-    }
-  });
+    it("geodesicSpec(diameter) produces a line through ±dir", () => {
+        const a = angleToBoundaryPoint(0);
+        const b = angleToBoundaryPoint(Math.PI);
+        const g: Geodesic = geodesicFromBoundary(a, b);
+        expect(g.kind).toBe("diameter");
+        const s = geodesicSpec(g, identity);
+        if ("x1" in s) {
+            expect(close(s.y1, s.y2)).toBe(true); // horizontal line
+            expect(close(s.x1, -1) && close(s.x2, 1)).toBe(true);
+        } else {
+            throw new Error("expected line spec");
+        }
+    });
 });
-

--- a/tests/unit/render/viewport.test.ts
+++ b/tests/unit/render/viewport.test.ts
@@ -1,0 +1,49 @@
+/* @vitest-environment jsdom */
+import { describe, expect, it } from "vitest";
+
+import { compose, identity, invert, screenToWorld, worldToScreen, type Viewport } from "../../../src/render/viewport";
+
+const close = (a: number, b: number, d = 1e-12) => Math.abs(a - b) <= d;
+
+describe("render/viewport", () => {
+  it("round-trips world -> screen -> world", () => {
+    const vp: Viewport = { scale: 2.5, tx: 100, ty: -40 };
+    const p = { x: -3.2, y: 7.75 };
+    const s = worldToScreen(vp, p);
+    const q = screenToWorld(vp, s);
+    expect(close(q.x, p.x)).toBe(true);
+    expect(close(q.y, p.y)).toBe(true);
+  });
+
+  it("identity leaves points unchanged", () => {
+    const p = { x: 12.34, y: -56.78 };
+    const s = worldToScreen(identity, p);
+    expect(close(s.x, p.x)).toBe(true);
+    expect(close(s.y, p.y)).toBe(true);
+    const w = screenToWorld(identity, s);
+    expect(close(w.x, p.x)).toBe(true);
+    expect(close(w.y, p.y)).toBe(true);
+  });
+
+  it("invert produces a transform that undoes the original", () => {
+    const vp: Viewport = { scale: 1.75, tx: -20, ty: 80 };
+    const inv = invert(vp);
+    const p = { x: 4, y: -9 };
+    const s = worldToScreen(vp, p);
+    const back = worldToScreen(inv, s); // treat inv as world->screen acting on screen-space
+    expect(close(back.x, p.x)).toBe(true);
+    expect(close(back.y, p.y)).toBe(true);
+  });
+
+  it("composition matches sequential application", () => {
+    const a: Viewport = { scale: 0.5, tx: 10, ty: 20 };
+    const b: Viewport = { scale: 3, tx: -5, ty: 7 };
+    const c = compose(b, a); // apply a then b
+    const p = { x: 2, y: -1 };
+    const seq = worldToScreen(b, worldToScreen(a, p));
+    const one = worldToScreen(c, p);
+    expect(close(one.x, seq.x)).toBe(true);
+    expect(close(one.y, seq.y)).toBe(true);
+  });
+});
+

--- a/tests/unit/render/viewport.test.ts
+++ b/tests/unit/render/viewport.test.ts
@@ -1,49 +1,55 @@
 /* @vitest-environment jsdom */
 import { describe, expect, it } from "vitest";
 
-import { compose, identity, invert, screenToWorld, worldToScreen, type Viewport } from "../../../src/render/viewport";
+import {
+    compose,
+    identity,
+    invert,
+    screenToWorld,
+    type Viewport,
+    worldToScreen,
+} from "../../../src/render/viewport";
 
 const close = (a: number, b: number, d = 1e-12) => Math.abs(a - b) <= d;
 
 describe("render/viewport", () => {
-  it("round-trips world -> screen -> world", () => {
-    const vp: Viewport = { scale: 2.5, tx: 100, ty: -40 };
-    const p = { x: -3.2, y: 7.75 };
-    const s = worldToScreen(vp, p);
-    const q = screenToWorld(vp, s);
-    expect(close(q.x, p.x)).toBe(true);
-    expect(close(q.y, p.y)).toBe(true);
-  });
+    it("round-trips world -> screen -> world", () => {
+        const vp: Viewport = { scale: 2.5, tx: 100, ty: -40 };
+        const p = { x: -3.2, y: 7.75 };
+        const s = worldToScreen(vp, p);
+        const q = screenToWorld(vp, s);
+        expect(close(q.x, p.x)).toBe(true);
+        expect(close(q.y, p.y)).toBe(true);
+    });
 
-  it("identity leaves points unchanged", () => {
-    const p = { x: 12.34, y: -56.78 };
-    const s = worldToScreen(identity, p);
-    expect(close(s.x, p.x)).toBe(true);
-    expect(close(s.y, p.y)).toBe(true);
-    const w = screenToWorld(identity, s);
-    expect(close(w.x, p.x)).toBe(true);
-    expect(close(w.y, p.y)).toBe(true);
-  });
+    it("identity leaves points unchanged", () => {
+        const p = { x: 12.34, y: -56.78 };
+        const s = worldToScreen(identity, p);
+        expect(close(s.x, p.x)).toBe(true);
+        expect(close(s.y, p.y)).toBe(true);
+        const w = screenToWorld(identity, s);
+        expect(close(w.x, p.x)).toBe(true);
+        expect(close(w.y, p.y)).toBe(true);
+    });
 
-  it("invert produces a transform that undoes the original", () => {
-    const vp: Viewport = { scale: 1.75, tx: -20, ty: 80 };
-    const inv = invert(vp);
-    const p = { x: 4, y: -9 };
-    const s = worldToScreen(vp, p);
-    const back = worldToScreen(inv, s); // treat inv as world->screen acting on screen-space
-    expect(close(back.x, p.x)).toBe(true);
-    expect(close(back.y, p.y)).toBe(true);
-  });
+    it("invert produces a transform that undoes the original", () => {
+        const vp: Viewport = { scale: 1.75, tx: -20, ty: 80 };
+        const inv = invert(vp);
+        const p = { x: 4, y: -9 };
+        const s = worldToScreen(vp, p);
+        const back = worldToScreen(inv, s); // treat inv as world->screen acting on screen-space
+        expect(close(back.x, p.x)).toBe(true);
+        expect(close(back.y, p.y)).toBe(true);
+    });
 
-  it("composition matches sequential application", () => {
-    const a: Viewport = { scale: 0.5, tx: 10, ty: 20 };
-    const b: Viewport = { scale: 3, tx: -5, ty: 7 };
-    const c = compose(b, a); // apply a then b
-    const p = { x: 2, y: -1 };
-    const seq = worldToScreen(b, worldToScreen(a, p));
-    const one = worldToScreen(c, p);
-    expect(close(one.x, seq.x)).toBe(true);
-    expect(close(one.y, seq.y)).toBe(true);
-  });
+    it("composition matches sequential application", () => {
+        const a: Viewport = { scale: 0.5, tx: 10, ty: 20 };
+        const b: Viewport = { scale: 3, tx: -5, ty: 7 };
+        const c = compose(b, a); // apply a then b
+        const p = { x: 2, y: -1 };
+        const seq = worldToScreen(b, worldToScreen(a, p));
+        const one = worldToScreen(c, p);
+        expect(close(one.x, seq.x)).toBe(true);
+        expect(close(one.y, seq.y)).toBe(true);
+    });
 });
-

--- a/tests/unit/ui/app.render.test.tsx
+++ b/tests/unit/ui/app.render.test.tsx
@@ -1,17 +1,17 @@
-import { describe, it, expect } from "vitest";
 import { createRoot } from "react-dom/client";
 import { act } from "react-dom/test-utils";
+import { describe, expect, it } from "vitest";
 import { App } from "../../../src/ui/App";
 
 // Minimal render test to ensure #stage canvas exists
 describe("App", () => {
     it("renders a canvas with id #stage", async () => {
-    const host = document.createElement("div");
-    document.body.appendChild(host);
-    const root = createRoot(host);
-    await act(async () => {
-      root.render(<App />);
-    });
+        const host = document.createElement("div");
+        document.body.appendChild(host);
+        const root = createRoot(host);
+        await act(async () => {
+            root.render(<App />);
+        });
         const stage = host.querySelector("#stage") as HTMLCanvasElement | null;
         expect(stage).not.toBeNull();
         if (stage) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
 
 export default defineConfig({
     plugins: [react()],


### PR DESCRIPTION
Closes #39
Closes #40
Closes #41

## 目的（Why）
- Poincaré円板の最小描画体験を作るため、レンダ基盤セット（Viewport/Invalidation/Primitives）を一括実装。
- UI/デモ実装や後続の最適化（カリング/PNG/診断）の前提を整える。

## 変更点（What）
- render/viewport: `Viewport` 型と基本変換
  - `identity`, `worldToScreen`, `screenToWorld`, `compose(b,a)`, `invert`
- render/invalidation: Dirty矩形管理とフレームcoalesce
  - `intersects/adjacent/union`、`InvalidationScheduler.invalidate/flush/dispose`
- render/primitives: 描画仕様（数値）
  - `unitDiskSpec(vp)`, `geodesicSpec(geo,vp)`（円 or 直線のスペックを返す）
- tests: 上記のユニットテスト一式（round-trip/合成/逆変換、矩形結合/隣接、スペック算出）

## 技術詳細（How）
- Viewportは等方スケール+平行移動（2Dアフィンの極小形）で定義。合成と逆変換を明示。
- Invalidationは矩形の交差/隣接でマージする単純O(n^2)方式（WP範囲）。必要ならSweep-lineへ拡張可。
- Primitivesはjsdom環境を考慮し、Canvas API直接ではなく数値スペックを返す設計。

## スクリーンショット / 動作デモ
- 単体（jsdom）で検証。UI配線は後続WPで対応。

## 受け入れ条件（DoD）
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm run test:sandbox` が緑（coverage v8）
- [x] ビューポート round-trip/合成/逆変換のテストが緑
- [x] invalidation の coalesce/矩形結合テストが緑
- [x] primitives のジオデシック/単位円スペックが緑

## 確認手順（Reviewer 向け）
```bash
pnpm i
pnpm lint && pnpm typecheck && pnpm run test:sandbox
```

## リスクとロールバック
- 影響: render 名前空間に新規追加のみ（既存API非変更）
- リスク: 今後の最適化時に invalidation のマージ戦略を見直す可能性
- ロールバック: このPRのrevertで元に戻せます（新規ファイル中心）

## Out of Scope（別PR）
- カリング/バッチ描画（#42）
- PNGエクスポート（#43）
- 診断オーバーレイ（#44）

## 関連 Issue / PR
- Refs #27 (UI Epic), #37 (Render Parent)
