### PR TITLE
feat(render): unit disk MVP (specs→canvas adapter → App)

### DIFF
--- a/src/render/canvasAdapter.ts
+++ b/src/render/canvasAdapter.ts
@@ -1,0 +1,43 @@
+import type { CircleSpec, LineSpec } from "./primitives";
+
+export type StrokeStyle = { strokeStyle?: string; lineWidth?: number };
+
+function align05(x: number): number {
+  // align 1px strokes to device pixel grid to avoid blur
+  return Math.round(x) + 0.5;
+}
+
+export function drawCircle(ctx: CanvasRenderingContext2D, c: CircleSpec, style: StrokeStyle = {}): void {
+  const { strokeStyle = "#222", lineWidth = 1 } = style;
+  ctx.save();
+  ctx.beginPath();
+  // pixel-align by nudging center for 1px strokes (simple heuristic)
+  const cx = lineWidth === 1 ? align05(c.cx) : c.cx;
+  const cy = lineWidth === 1 ? align05(c.cy) : c.cy;
+  ctx.arc(cx, cy, c.r, 0, Math.PI * 2);
+  ctx.lineWidth = lineWidth;
+  ctx.strokeStyle = strokeStyle as string;
+  ctx.stroke();
+  ctx.restore();
+}
+
+export function drawLine(ctx: CanvasRenderingContext2D, l: LineSpec, style: StrokeStyle = {}): void {
+  const { strokeStyle = "#222", lineWidth = 1 } = style;
+  ctx.save();
+  ctx.beginPath();
+  const x1 = lineWidth === 1 ? align05(l.x1) : l.x1;
+  const y1 = lineWidth === 1 ? align05(l.y1) : l.y1;
+  const x2 = lineWidth === 1 ? align05(l.x2) : l.x2;
+  const y2 = lineWidth === 1 ? align05(l.y2) : l.y2;
+  ctx.moveTo(x1, y1);
+  ctx.lineTo(x2, y2);
+  ctx.lineWidth = lineWidth;
+  ctx.strokeStyle = strokeStyle as string;
+  ctx.stroke();
+  ctx.restore();
+}
+
+export function clearRects(ctx: CanvasRenderingContext2D, rects: Array<{ x: number; y: number; w: number; h: number }>): void {
+  for (const r of rects) ctx.clearRect(r.x, r.y, r.w, r.h);
+}
+

--- a/src/render/canvasAdapter.ts
+++ b/src/render/canvasAdapter.ts
@@ -3,41 +3,51 @@ import type { CircleSpec, LineSpec } from "./primitives";
 export type StrokeStyle = { strokeStyle?: string; lineWidth?: number };
 
 function align05(x: number): number {
-  // align 1px strokes to device pixel grid to avoid blur
-  return Math.round(x) + 0.5;
+    // align 1px strokes to device pixel grid to avoid blur
+    return Math.round(x) + 0.5;
 }
 
-export function drawCircle(ctx: CanvasRenderingContext2D, c: CircleSpec, style: StrokeStyle = {}): void {
-  const { strokeStyle = "#222", lineWidth = 1 } = style;
-  ctx.save();
-  ctx.beginPath();
-  // pixel-align by nudging center for 1px strokes (simple heuristic)
-  const cx = lineWidth === 1 ? align05(c.cx) : c.cx;
-  const cy = lineWidth === 1 ? align05(c.cy) : c.cy;
-  ctx.arc(cx, cy, c.r, 0, Math.PI * 2);
-  ctx.lineWidth = lineWidth;
-  ctx.strokeStyle = strokeStyle as string;
-  ctx.stroke();
-  ctx.restore();
+export function drawCircle(
+    ctx: CanvasRenderingContext2D,
+    c: CircleSpec,
+    style: StrokeStyle = {},
+): void {
+    const { strokeStyle = "#222", lineWidth = 1 } = style;
+    ctx.save();
+    ctx.beginPath();
+    // pixel-align by nudging center for 1px strokes (simple heuristic)
+    const cx = lineWidth === 1 ? align05(c.cx) : c.cx;
+    const cy = lineWidth === 1 ? align05(c.cy) : c.cy;
+    ctx.arc(cx, cy, c.r, 0, Math.PI * 2);
+    ctx.lineWidth = lineWidth;
+    ctx.strokeStyle = strokeStyle as string;
+    ctx.stroke();
+    ctx.restore();
 }
 
-export function drawLine(ctx: CanvasRenderingContext2D, l: LineSpec, style: StrokeStyle = {}): void {
-  const { strokeStyle = "#222", lineWidth = 1 } = style;
-  ctx.save();
-  ctx.beginPath();
-  const x1 = lineWidth === 1 ? align05(l.x1) : l.x1;
-  const y1 = lineWidth === 1 ? align05(l.y1) : l.y1;
-  const x2 = lineWidth === 1 ? align05(l.x2) : l.x2;
-  const y2 = lineWidth === 1 ? align05(l.y2) : l.y2;
-  ctx.moveTo(x1, y1);
-  ctx.lineTo(x2, y2);
-  ctx.lineWidth = lineWidth;
-  ctx.strokeStyle = strokeStyle as string;
-  ctx.stroke();
-  ctx.restore();
+export function drawLine(
+    ctx: CanvasRenderingContext2D,
+    l: LineSpec,
+    style: StrokeStyle = {},
+): void {
+    const { strokeStyle = "#222", lineWidth = 1 } = style;
+    ctx.save();
+    ctx.beginPath();
+    const x1 = lineWidth === 1 ? align05(l.x1) : l.x1;
+    const y1 = lineWidth === 1 ? align05(l.y1) : l.y1;
+    const x2 = lineWidth === 1 ? align05(l.x2) : l.x2;
+    const y2 = lineWidth === 1 ? align05(l.y2) : l.y2;
+    ctx.moveTo(x1, y1);
+    ctx.lineTo(x2, y2);
+    ctx.lineWidth = lineWidth;
+    ctx.strokeStyle = strokeStyle as string;
+    ctx.stroke();
+    ctx.restore();
 }
 
-export function clearRects(ctx: CanvasRenderingContext2D, rects: Array<{ x: number; y: number; w: number; h: number }>): void {
-  for (const r of rects) ctx.clearRect(r.x, r.y, r.w, r.h);
+export function clearRects(
+    ctx: CanvasRenderingContext2D,
+    rects: Array<{ x: number; y: number; w: number; h: number }>,
+): void {
+    for (const r of rects) ctx.clearRect(r.x, r.y, r.w, r.h);
 }
-

--- a/src/render/export.ts
+++ b/src/render/export.ts
@@ -6,27 +6,27 @@ export type ExportOptions = { scale?: number; background?: string };
  * - background: optional fill color (e.g., "white"); otherwise transparent
  */
 export function exportPNG(source: HTMLCanvasElement, opts: ExportOptions = {}): string {
-  const scale = typeof opts.scale === "number" && isFinite(opts.scale) && opts.scale > 0 ? opts.scale : 1;
-  // If no scaling and no background, delegate directly
-  if (scale === 1 && !(opts.background)) {
-    const d = (source as any).toDataURL?.("image/png");
-    if (typeof d === "string") return d;
-  }
-  const target = document.createElement("canvas");
-  target.width = Math.max(1, Math.round(source.width * scale));
-  target.height = Math.max(1, Math.round(source.height * scale));
-  const ctx = target.getContext("2d");
-  if (ctx) {
-    if (opts.background) {
-      ctx.save();
-      ctx.fillStyle = opts.background;
-      ctx.fillRect(0, 0, target.width, target.height);
-      ctx.restore();
+    const scale =
+        typeof opts.scale === "number" && isFinite(opts.scale) && opts.scale > 0 ? opts.scale : 1;
+    // If no scaling and no background, delegate directly
+    if (scale === 1 && !opts.background) {
+        const d = (source as any).toDataURL?.("image/png");
+        if (typeof d === "string") return d;
     }
-    // drawImage is a no-op in jsdom, but safe; scale with drawImage when needed
-    ctx.drawImage(source, 0, 0, source.width, source.height, 0, 0, target.width, target.height);
-  }
-  const data = (target as any).toDataURL?.("image/png");
-  return typeof data === "string" ? data : "data:image/png;base64,";
+    const target = document.createElement("canvas");
+    target.width = Math.max(1, Math.round(source.width * scale));
+    target.height = Math.max(1, Math.round(source.height * scale));
+    const ctx = target.getContext("2d");
+    if (ctx) {
+        if (opts.background) {
+            ctx.save();
+            ctx.fillStyle = opts.background;
+            ctx.fillRect(0, 0, target.width, target.height);
+            ctx.restore();
+        }
+        // drawImage is a no-op in jsdom, but safe; scale with drawImage when needed
+        ctx.drawImage(source, 0, 0, source.width, source.height, 0, 0, target.width, target.height);
+    }
+    const data = (target as any).toDataURL?.("image/png");
+    return typeof data === "string" ? data : "data:image/png;base64,";
 }
-

--- a/src/render/export.ts
+++ b/src/render/export.ts
@@ -1,0 +1,32 @@
+export type ExportOptions = { scale?: number; background?: string };
+
+/**
+ * Export current canvas content as PNG dataURL.
+ * - scale: multiplies pixel dimensions (uses an intermediate canvas when !=1)
+ * - background: optional fill color (e.g., "white"); otherwise transparent
+ */
+export function exportPNG(source: HTMLCanvasElement, opts: ExportOptions = {}): string {
+  const scale = typeof opts.scale === "number" && isFinite(opts.scale) && opts.scale > 0 ? opts.scale : 1;
+  // If no scaling and no background, delegate directly
+  if (scale === 1 && !(opts.background)) {
+    const d = (source as any).toDataURL?.("image/png");
+    if (typeof d === "string") return d;
+  }
+  const target = document.createElement("canvas");
+  target.width = Math.max(1, Math.round(source.width * scale));
+  target.height = Math.max(1, Math.round(source.height * scale));
+  const ctx = target.getContext("2d");
+  if (ctx) {
+    if (opts.background) {
+      ctx.save();
+      ctx.fillStyle = opts.background;
+      ctx.fillRect(0, 0, target.width, target.height);
+      ctx.restore();
+    }
+    // drawImage is a no-op in jsdom, but safe; scale with drawImage when needed
+    ctx.drawImage(source, 0, 0, source.width, source.height, 0, 0, target.width, target.height);
+  }
+  const data = (target as any).toDataURL?.("image/png");
+  return typeof data === "string" ? data : "data:image/png;base64,";
+}
+

--- a/src/render/invalidation.ts
+++ b/src/render/invalidation.ts
@@ -132,11 +132,11 @@ export class InvalidationScheduler {
      * 即時にマージと通知を行います（通常は RAF により内部から呼ばれます）。
      */
     flush(): void {
-    if (this.rafId !== null) {
-      const caf = globalThis.cancelAnimationFrame?.bind(globalThis);
-      if (caf) caf(this.rafId);
-      this.rafId = null;
-    }
+        if (this.rafId !== null) {
+            const caf = globalThis.cancelAnimationFrame?.bind(globalThis);
+            if (caf) caf(this.rafId);
+            this.rafId = null;
+        }
         if (this.pending.length === 0) return;
         const merged = mergeRects(this.pending);
         this.pending = [];
@@ -147,10 +147,10 @@ export class InvalidationScheduler {
      * 保留キューを破棄し、将来のフラッシュを止めます。
      */
     dispose(): void {
-    if (this.rafId !== null) {
-      const caf = globalThis.cancelAnimationFrame?.bind(globalThis);
-      if (caf) caf(this.rafId);
-    }
+        if (this.rafId !== null) {
+            const caf = globalThis.cancelAnimationFrame?.bind(globalThis);
+            if (caf) caf(this.rafId);
+        }
         this.rafId = null;
         this.pending = [];
     }

--- a/src/render/invalidation.ts
+++ b/src/render/invalidation.ts
@@ -132,10 +132,11 @@ export class InvalidationScheduler {
      * 即時にマージと通知を行います（通常は RAF により内部から呼ばれます）。
      */
     flush(): void {
-        if (this.rafId !== null && globalThis.cancelAnimationFrame) {
-            // not strictly necessary; frame just fired
-            this.rafId = null;
-        }
+    if (this.rafId !== null) {
+      const caf = globalThis.cancelAnimationFrame?.bind(globalThis);
+      if (caf) caf(this.rafId);
+      this.rafId = null;
+    }
         if (this.pending.length === 0) return;
         const merged = mergeRects(this.pending);
         this.pending = [];
@@ -146,9 +147,10 @@ export class InvalidationScheduler {
      * 保留キューを破棄し、将来のフラッシュを止めます。
      */
     dispose(): void {
-        if (this.rafId !== null && globalThis.cancelAnimationFrame) {
-            globalThis.cancelAnimationFrame(this.rafId);
-        }
+    if (this.rafId !== null) {
+      const caf = globalThis.cancelAnimationFrame?.bind(globalThis);
+      if (caf) caf(this.rafId);
+    }
         this.rafId = null;
         this.pending = [];
     }

--- a/src/render/stats.ts
+++ b/src/render/stats.ts
@@ -2,18 +2,17 @@
  * FpsAverager: maintain moving average FPS over a sliding window of N samples.
  */
 export class FpsAverager {
-  private times: number[] = [];
-  constructor(private windowSize = 60) {}
-  push(nowMs: number): void {
-    this.times.push(nowMs);
-    while (this.times.length > this.windowSize) this.times.shift();
-  }
-  get fps(): number {
-    if (this.times.length < 2) return 0;
-    const first = this.times[0]!
-    const last = this.times[this.times.length - 1]!
-    const dt = (last - first) / (this.times.length - 1);
-    return dt > 0 ? 1000 / dt : 0;
-  }
+    private times: number[] = [];
+    constructor(private windowSize = 60) {}
+    push(nowMs: number): void {
+        this.times.push(nowMs);
+        while (this.times.length > this.windowSize) this.times.shift();
+    }
+    get fps(): number {
+        if (this.times.length < 2) return 0;
+        const first = this.times[0]!;
+        const last = this.times[this.times.length - 1]!;
+        const dt = (last - first) / (this.times.length - 1);
+        return dt > 0 ? 1000 / dt : 0;
+    }
 }
-

--- a/src/render/stats.ts
+++ b/src/render/stats.ts
@@ -1,0 +1,19 @@
+/**
+ * FpsAverager: maintain moving average FPS over a sliding window of N samples.
+ */
+export class FpsAverager {
+  private times: number[] = [];
+  constructor(private windowSize = 60) {}
+  push(nowMs: number): void {
+    this.times.push(nowMs);
+    while (this.times.length > this.windowSize) this.times.shift();
+  }
+  get fps(): number {
+    if (this.times.length < 2) return 0;
+    const first = this.times[0]!
+    const last = this.times[this.times.length - 1]!
+    const dt = (last - first) / (this.times.length - 1);
+    return dt > 0 ? 1000 / dt : 0;
+  }
+}
+

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef } from "react";
-import { setCanvasDPR, attachResize } from "../render/canvas";
-import { type Viewport } from "../render/viewport";
-import { unitDiskSpec } from "../render/primitives";
+import { attachResize, setCanvasDPR } from "../render/canvas";
 import { drawCircle } from "../render/canvasAdapter";
+import { unitDiskSpec } from "../render/primitives";
+import type { Viewport } from "../render/viewport";
 
 export function App(): JSX.Element {
     const canvasRef = useRef<HTMLCanvasElement | null>(null);

--- a/tests/unit/render/canvas.adapter.test.ts
+++ b/tests/unit/render/canvas.adapter.test.ts
@@ -3,33 +3,37 @@ import { describe, expect, it, vi } from "vitest";
 import { drawCircle, drawLine } from "../../../src/render/canvasAdapter";
 
 function makeCtx() {
-  return {
-    save: vi.fn(), restore: vi.fn(), beginPath: vi.fn(),
-    arc: vi.fn(), moveTo: vi.fn(), lineTo: vi.fn(), stroke: vi.fn(),
-    clearRect: vi.fn(),
-    lineWidth: 0,
-    strokeStyle: "",
-  } as unknown as CanvasRenderingContext2D;
+    return {
+        save: vi.fn(),
+        restore: vi.fn(),
+        beginPath: vi.fn(),
+        arc: vi.fn(),
+        moveTo: vi.fn(),
+        lineTo: vi.fn(),
+        stroke: vi.fn(),
+        clearRect: vi.fn(),
+        lineWidth: 0,
+        strokeStyle: "",
+    } as unknown as CanvasRenderingContext2D;
 }
 
 describe("render/canvasAdapter", () => {
-  it("drawCircle issues arc+stroke", () => {
-    const ctx = makeCtx();
-    drawCircle(ctx, { cx: 10, cy: 20, r: 5 });
-    const anyCtx = ctx as any;
-    expect(anyCtx.beginPath).toHaveBeenCalledTimes(1);
-    expect(anyCtx.arc).toHaveBeenCalledTimes(1);
-    expect(anyCtx.stroke).toHaveBeenCalledTimes(1);
-  });
+    it("drawCircle issues arc+stroke", () => {
+        const ctx = makeCtx();
+        drawCircle(ctx, { cx: 10, cy: 20, r: 5 });
+        const anyCtx = ctx as any;
+        expect(anyCtx.beginPath).toHaveBeenCalledTimes(1);
+        expect(anyCtx.arc).toHaveBeenCalledTimes(1);
+        expect(anyCtx.stroke).toHaveBeenCalledTimes(1);
+    });
 
-  it("drawLine issues moveTo/lineTo+stroke", () => {
-    const ctx = makeCtx();
-    drawLine(ctx, { x1: 0, y1: 1, x2: 2, y2: 3 });
-    const anyCtx = ctx as any;
-    expect(anyCtx.beginPath).toHaveBeenCalledTimes(1);
-    expect(anyCtx.moveTo).toHaveBeenCalledTimes(1);
-    expect(anyCtx.lineTo).toHaveBeenCalledTimes(1);
-    expect(anyCtx.stroke).toHaveBeenCalledTimes(1);
-  });
+    it("drawLine issues moveTo/lineTo+stroke", () => {
+        const ctx = makeCtx();
+        drawLine(ctx, { x1: 0, y1: 1, x2: 2, y2: 3 });
+        const anyCtx = ctx as any;
+        expect(anyCtx.beginPath).toHaveBeenCalledTimes(1);
+        expect(anyCtx.moveTo).toHaveBeenCalledTimes(1);
+        expect(anyCtx.lineTo).toHaveBeenCalledTimes(1);
+        expect(anyCtx.stroke).toHaveBeenCalledTimes(1);
+    });
 });
-

--- a/tests/unit/render/canvas.adapter.test.ts
+++ b/tests/unit/render/canvas.adapter.test.ts
@@ -1,0 +1,35 @@
+/* @vitest-environment jsdom */
+import { describe, expect, it, vi } from "vitest";
+import { drawCircle, drawLine } from "../../../src/render/canvasAdapter";
+
+function makeCtx() {
+  return {
+    save: vi.fn(), restore: vi.fn(), beginPath: vi.fn(),
+    arc: vi.fn(), moveTo: vi.fn(), lineTo: vi.fn(), stroke: vi.fn(),
+    clearRect: vi.fn(),
+    lineWidth: 0,
+    strokeStyle: "",
+  } as unknown as CanvasRenderingContext2D;
+}
+
+describe("render/canvasAdapter", () => {
+  it("drawCircle issues arc+stroke", () => {
+    const ctx = makeCtx();
+    drawCircle(ctx, { cx: 10, cy: 20, r: 5 });
+    const anyCtx = ctx as any;
+    expect(anyCtx.beginPath).toHaveBeenCalledTimes(1);
+    expect(anyCtx.arc).toHaveBeenCalledTimes(1);
+    expect(anyCtx.stroke).toHaveBeenCalledTimes(1);
+  });
+
+  it("drawLine issues moveTo/lineTo+stroke", () => {
+    const ctx = makeCtx();
+    drawLine(ctx, { x1: 0, y1: 1, x2: 2, y2: 3 });
+    const anyCtx = ctx as any;
+    expect(anyCtx.beginPath).toHaveBeenCalledTimes(1);
+    expect(anyCtx.moveTo).toHaveBeenCalledTimes(1);
+    expect(anyCtx.lineTo).toHaveBeenCalledTimes(1);
+    expect(anyCtx.stroke).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/tests/unit/render/canvas.dpr.test.ts
+++ b/tests/unit/render/canvas.dpr.test.ts
@@ -4,9 +4,8 @@ import { attachResize, setCanvasDPR } from "../../../src/render/canvas";
 
 function makeCanvas(cssW: number, cssH: number): HTMLCanvasElement {
     const cv = document.createElement("canvas");
-    // mock layout size
-    // @ts-expect-error jsdom allows overriding this method
-    cv.getBoundingClientRect = () => ({
+  // mock layout size
+  cv.getBoundingClientRect = () => ({
         x: 0,
         y: 0,
         top: 0,
@@ -33,16 +32,14 @@ describe("render/canvas DPR utilities", () => {
 
     it("uses devicePixelRatio when param omitted", () => {
         const old = globalThis.devicePixelRatio as unknown as number | undefined;
-        // @ts-expect-error allow write
-        globalThis.devicePixelRatio = 1.5;
+    (globalThis as any).devicePixelRatio = 1.5;
         const cv = makeCanvas(400, 300);
         const dpr = setCanvasDPR(cv);
         expect(dpr).toBeCloseTo(1.5, 12);
         expect(cv.width).toBe(600);
         expect(cv.height).toBe(450);
         // restore
-        // @ts-expect-error allow write
-        globalThis.devicePixelRatio = old ?? 1;
+    (globalThis as any).devicePixelRatio = old ?? 1;
     });
 
     it("attachResize wires and unwires window resize", () => {

--- a/tests/unit/render/canvas.dpr.test.ts
+++ b/tests/unit/render/canvas.dpr.test.ts
@@ -4,8 +4,8 @@ import { attachResize, setCanvasDPR } from "../../../src/render/canvas";
 
 function makeCanvas(cssW: number, cssH: number): HTMLCanvasElement {
     const cv = document.createElement("canvas");
-  // mock layout size
-  cv.getBoundingClientRect = () => ({
+    // mock layout size
+    cv.getBoundingClientRect = () => ({
         x: 0,
         y: 0,
         top: 0,
@@ -32,14 +32,14 @@ describe("render/canvas DPR utilities", () => {
 
     it("uses devicePixelRatio when param omitted", () => {
         const old = globalThis.devicePixelRatio as unknown as number | undefined;
-    (globalThis as any).devicePixelRatio = 1.5;
+        (globalThis as any).devicePixelRatio = 1.5;
         const cv = makeCanvas(400, 300);
         const dpr = setCanvasDPR(cv);
         expect(dpr).toBeCloseTo(1.5, 12);
         expect(cv.width).toBe(600);
         expect(cv.height).toBe(450);
         // restore
-    (globalThis as any).devicePixelRatio = old ?? 1;
+        (globalThis as any).devicePixelRatio = old ?? 1;
     });
 
     it("attachResize wires and unwires window resize", () => {

--- a/tests/unit/render/export.test.ts
+++ b/tests/unit/render/export.test.ts
@@ -3,37 +3,37 @@ import { describe, expect, it, vi } from "vitest";
 import { exportPNG } from "../../../src/render/export";
 
 function makeCanvas(w = 100, h = 50) {
-  const cv = document.createElement("canvas");
-  cv.width = w; cv.height = h;
-  // stub toDataURL
-  (cv as any).toDataURL = vi.fn().mockReturnValue("data:image/png;base64,AAAA");
-  return cv as HTMLCanvasElement;
+    const cv = document.createElement("canvas");
+    cv.width = w;
+    cv.height = h;
+    // stub toDataURL
+    (cv as any).toDataURL = vi.fn().mockReturnValue("data:image/png;base64,AAAA");
+    return cv as HTMLCanvasElement;
 }
 
 describe("render/exportPNG", () => {
-  it("returns PNG dataURL (direct path)", () => {
-    const cv = makeCanvas();
-    const d = exportPNG(cv);
-    expect(d.startsWith("data:image/png")).toBe(true);
-  });
-
-  it("scales via intermediate canvas when scale!=1", () => {
-    const cv = makeCanvas(120, 80);
-    // spy on created canvas
-    const created: HTMLCanvasElement[] = [];
-    const orig = document.createElement.bind(document);
-    vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
-      const el = orig(tag) as any;
-      if (tag === "canvas") {
-        (el as any).toDataURL = vi.fn().mockReturnValue("data:image/png;base64,BBBB");
-        created.push(el);
-      }
-      return el;
+    it("returns PNG dataURL (direct path)", () => {
+        const cv = makeCanvas();
+        const d = exportPNG(cv);
+        expect(d.startsWith("data:image/png")).toBe(true);
     });
-    const d = exportPNG(cv, { scale: 2 });
-    expect(d.startsWith("data:image/png")).toBe(true);
-    expect(created[0]?.width).toBe(240);
-    expect(created[0]?.height).toBe(160);
-  });
-});
 
+    it("scales via intermediate canvas when scale!=1", () => {
+        const cv = makeCanvas(120, 80);
+        // spy on created canvas
+        const created: HTMLCanvasElement[] = [];
+        const orig = document.createElement.bind(document);
+        vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+            const el = orig(tag) as any;
+            if (tag === "canvas") {
+                (el as any).toDataURL = vi.fn().mockReturnValue("data:image/png;base64,BBBB");
+                created.push(el);
+            }
+            return el;
+        });
+        const d = exportPNG(cv, { scale: 2 });
+        expect(d.startsWith("data:image/png")).toBe(true);
+        expect(created[0]?.width).toBe(240);
+        expect(created[0]?.height).toBe(160);
+    });
+});

--- a/tests/unit/render/export.test.ts
+++ b/tests/unit/render/export.test.ts
@@ -1,0 +1,39 @@
+/* @vitest-environment jsdom */
+import { describe, expect, it, vi } from "vitest";
+import { exportPNG } from "../../../src/render/export";
+
+function makeCanvas(w = 100, h = 50) {
+  const cv = document.createElement("canvas");
+  cv.width = w; cv.height = h;
+  // stub toDataURL
+  (cv as any).toDataURL = vi.fn().mockReturnValue("data:image/png;base64,AAAA");
+  return cv as HTMLCanvasElement;
+}
+
+describe("render/exportPNG", () => {
+  it("returns PNG dataURL (direct path)", () => {
+    const cv = makeCanvas();
+    const d = exportPNG(cv);
+    expect(d.startsWith("data:image/png")).toBe(true);
+  });
+
+  it("scales via intermediate canvas when scale!=1", () => {
+    const cv = makeCanvas(120, 80);
+    // spy on created canvas
+    const created: HTMLCanvasElement[] = [];
+    const orig = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+      const el = orig(tag) as any;
+      if (tag === "canvas") {
+        (el as any).toDataURL = vi.fn().mockReturnValue("data:image/png;base64,BBBB");
+        created.push(el);
+      }
+      return el;
+    });
+    const d = exportPNG(cv, { scale: 2 });
+    expect(d.startsWith("data:image/png")).toBe(true);
+    expect(created[0]?.width).toBe(240);
+    expect(created[0]?.height).toBe(160);
+  });
+});
+

--- a/tests/unit/render/primitives.test.ts
+++ b/tests/unit/render/primitives.test.ts
@@ -20,16 +20,16 @@ describe("render/primitives specs", () => {
     it("geodesicSpec(circle) produces screen circle", () => {
         const a = angleToBoundaryPoint(0);
         const b = angleToBoundaryPoint(Math.PI / 3);
-    const g: Geodesic = geodesicFromBoundary(a, b);
-    const vp = identity;
-    if (g.kind !== "circle") throw new Error("expected circle geodesic");
-    const s = geodesicSpec(g, vp);
-    if ("r" in s) {
-      // radius equals world radius when scale=1
-      expect(s.r).toBeCloseTo(g.r, 12);
-    } else {
-      throw new Error("expected circle spec");
-    }
+        const g: Geodesic = geodesicFromBoundary(a, b);
+        const vp = identity;
+        if (g.kind !== "circle") throw new Error("expected circle geodesic");
+        const s = geodesicSpec(g, vp);
+        if ("r" in s) {
+            // radius equals world radius when scale=1
+            expect(s.r).toBeCloseTo(g.r, 12);
+        } else {
+            throw new Error("expected circle spec");
+        }
     });
 
     it("geodesicSpec(diameter) produces a line through ±dir", () => {

--- a/tests/unit/render/primitives.test.ts
+++ b/tests/unit/render/primitives.test.ts
@@ -20,16 +20,16 @@ describe("render/primitives specs", () => {
     it("geodesicSpec(circle) produces screen circle", () => {
         const a = angleToBoundaryPoint(0);
         const b = angleToBoundaryPoint(Math.PI / 3);
-        const g: Geodesic = geodesicFromBoundary(a, b);
-        expect(g.kind).toBe("circle");
-        const vp = identity;
-        const s = geodesicSpec(g, vp);
-        if ("r" in s) {
-            // radius equals world radius when scale=1
-            expect(s.r).toBeCloseTo(g.r, 12);
-        } else {
-            throw new Error("expected circle spec");
-        }
+    const g: Geodesic = geodesicFromBoundary(a, b);
+    const vp = identity;
+    if (g.kind !== "circle") throw new Error("expected circle geodesic");
+    const s = geodesicSpec(g, vp);
+    if ("r" in s) {
+      // radius equals world radius when scale=1
+      expect(s.r).toBeCloseTo(g.r, 12);
+    } else {
+      throw new Error("expected circle spec");
+    }
     });
 
     it("geodesicSpec(diameter) produces a line through ±dir", () => {

--- a/tests/unit/render/stats.test.ts
+++ b/tests/unit/render/stats.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { FpsAverager } from "../../../src/render/stats";
+
+describe("render/FpsAverager", () => {
+  it("computes average fps over window", () => {
+    const fps = new FpsAverager(5);
+    // push timestamps every ~16.7ms (~60fps)
+    const start = 1000;
+    for (let i = 0; i < 6; i++) fps.push(start + i * 16.7);
+    expect(fps.fps).toBeGreaterThan(55);
+    expect(fps.fps).toBeLessThan(65);
+  });
+});
+

--- a/tests/unit/render/stats.test.ts
+++ b/tests/unit/render/stats.test.ts
@@ -2,13 +2,12 @@ import { describe, expect, it } from "vitest";
 import { FpsAverager } from "../../../src/render/stats";
 
 describe("render/FpsAverager", () => {
-  it("computes average fps over window", () => {
-    const fps = new FpsAverager(5);
-    // push timestamps every ~16.7ms (~60fps)
-    const start = 1000;
-    for (let i = 0; i < 6; i++) fps.push(start + i * 16.7);
-    expect(fps.fps).toBeGreaterThan(55);
-    expect(fps.fps).toBeLessThan(65);
-  });
+    it("computes average fps over window", () => {
+        const fps = new FpsAverager(5);
+        // push timestamps every ~16.7ms (~60fps)
+        const start = 1000;
+        for (let i = 0; i < 6; i++) fps.push(start + i * 16.7);
+        expect(fps.fps).toBeGreaterThan(55);
+        expect(fps.fps).toBeLessThan(65);
+    });
 });
-


### PR DESCRIPTION
Closes #48

## 目的
Spec→Adapter→App で単位円を描画する最小実装（移植性を維持）。

## 変更
- render/canvasAdapter: drawCircle/drawLine/clearRects（1px時のpixel-align）
- ui/App: Viewport計算 + Spec→Adapter で単位円描画、リサイズ再描画
- tests: adapterの最小ユニットテスト追加

## 確認手順
- pnpm dev → http://localhost:5173 で単位円が中央に表示
- リサイズで破綻しない
- pnpm run test:sandbox が緑

## 備考
- Invalidation連携は今後のWPで差分再描画に移行
- READMEのPortability方針に準拠
