### PR TITLE
feat(geom): 基本三角形の構成 (p,q,r) → mirrors/vertices

### DIFF
--- a/src/geom/triangle-fundamental.ts
+++ b/src/geom/triangle-fundamental.ts
@@ -1,0 +1,203 @@
+import type { Geodesic } from "./geodesic";
+import { geodesicFromBoundary } from "./geodesic";
+import type { Vec2 } from "./types";
+
+export type FundamentalTriangle = {
+    mirrors: [Geodesic, Geodesic, Geodesic];
+    vertices: [Vec2, Vec2, Vec2];
+    angles: [number, number, number];
+};
+
+const clamp = (x: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, x));
+
+function dir(theta: number): Vec2 {
+    return { x: Math.cos(theta), y: Math.sin(theta) };
+}
+
+function solveForThirdMirror(alpha: number, beta: number, gamma: number): { c: Vec2; r: number } {
+    // g1: x軸の直径, g2: 角度 alpha の直径
+    // P = g1∩g3 の角度を beta、Q = g2∩g3 の角度を gamma に合わせる。
+    const u = dir(alpha);
+
+    const angleAtQ = (t: number): number => {
+        // 与えた t に対し、beta を満たす cy を決定し、その上で Q 側角度を返す
+        const cx = (1 + t * t) / (2 * t);
+        const dx = t - cx; // = (t^2 - 1) / (2t)
+        const cy = Math.abs(dx) / Math.tan(beta);
+        const r = Math.hypot(dx, cy);
+        const cdotu = cx * u.x + cy * u.y;
+        // cc - r^2 = 1 により判別式は cdotu^2 - 1
+        const disc = Math.max(0, cdotu * cdotu - 1);
+        const s = cdotu - Math.sqrt(disc);
+        const qx = s * u.x,
+            qy = s * u.y;
+        const nx = (qx - cx) / r,
+            ny = (qy - cy) / r; // 半径方向の単位ベクトル
+        const dot = Math.abs(nx * u.x + ny * u.y); // tangent と u の角 = asin(|dot(n,u)|)
+        return Math.asin(clamp(dot, 0, 1));
+    };
+
+    // t ∈ (0,1) で f(t)=angleAtQ(t)-gamma を解く
+    const f = (t: number) => angleAtQ(t) - gamma;
+
+    // ブラケット探索
+    let a = 0.1,
+        b = 0.9;
+    let fa = f(a),
+        fb = f(b);
+    if (fa * fb > 0) {
+        // 粗探索で符号反転区間を探す
+        const N = 20;
+        let prevT = a,
+            prevF = fa;
+        let found = false;
+        for (let i = 1; i <= N; i++) {
+            const t = a + ((b - a) * i) / N;
+            const ft = f(t);
+            if (prevF * ft <= 0) {
+                a = prevT;
+                b = t;
+                fa = prevF;
+                fb = ft;
+                found = true;
+                break;
+            }
+            prevT = t;
+            prevF = ft;
+        }
+        if (!found) {
+            // 近い最小値で代替（secant 2ステップ）
+            let t0 = 0.5,
+                t1 = 0.6;
+            let f0 = f(t0),
+                f1 = f(t1);
+            for (let i = 0; i < 12; i++) {
+                const dt = (t1 - t0) / Math.max(1e-6, f1 - f0);
+                const t2 = clamp(t1 - f1 * dt, 0.05, 0.95);
+                t0 = t1;
+                f0 = f1;
+                t1 = t2;
+                f1 = f(t1);
+            }
+            const cx = (1 + t1 * t1) / (2 * t1);
+            const dx = t1 - cx;
+            const cy = Math.abs(dx) / Math.tan(beta);
+            const r = Math.hypot(dx, cy);
+            return { c: { x: cx, y: cy }, r };
+        }
+    }
+
+    // 二分法で収束
+    for (let i = 0; i < 60; i++) {
+        const m = 0.5 * (a + b);
+        const fm = f(m);
+        if (Math.abs(fm) < 5e-4 || Math.abs(b - a) < 1e-6) {
+            const cx = (1 + m * m) / (2 * m);
+            const dx = m - cx;
+            const cy = Math.abs(dx) / Math.tan(beta);
+            const r = Math.hypot(dx, cy);
+            return { c: { x: cx, y: cy }, r };
+        }
+        if (fa * fm <= 0) {
+            b = m;
+            fb = fm;
+        } else {
+            a = m;
+            fa = fm;
+        }
+    }
+    const m = 0.5 * (a + b);
+    const cx = (1 + m * m) / (2 * m);
+    const dx = m - cx;
+    const cy = Math.abs(dx) / Math.tan(beta);
+    const r = Math.hypot(dx, cy);
+    return { c: { x: cx, y: cy }, r };
+}
+
+export function buildFundamentalTriangle(p: number, q: number, r: number): FundamentalTriangle {
+    if (!(p > 1 && q > 1 && r > 1) || 1 / p + 1 / q + 1 / r >= 1) {
+        throw new Error("Invalid (p,q,r) for hyperbolic triangle");
+    }
+    const alpha = Math.PI / p;
+    const beta = Math.PI / q;
+    const gamma = Math.PI / r;
+
+    // g1, g2: diameters crossing at origin with angle alpha
+    // Create as geodesics from boundary: endpoints at angles 0 and π, and at α and α+π
+    const g1: Geodesic = geodesicFromBoundary({ x: 1, y: 0 }, { x: -1, y: 0 });
+    const aDir = dir(alpha);
+    const g2: Geodesic = geodesicFromBoundary(aDir, { x: -aDir.x, y: -aDir.y });
+
+    const third = solveForThirdMirror(alpha, beta, gamma);
+    const g3: Geodesic = { kind: "circle", c: third.c, r: third.r };
+
+    // vertices: v0 = origin (g1∩g2), v1 = g1∩g3 on x-axis, v2 = g2∩g3 on line alpha
+    const v0: Vec2 = { x: 0, y: 0 };
+    const t = third;
+    const cx = t.c.x,
+        cy = t.c.y,
+        rad = t.r;
+    // v1 on x-axis solves (x-cx)^2 + (0-cy)^2 = r^2 -> pick the one in (0,1)
+    const dx = Math.sqrt(Math.max(0, rad * rad - cy * cy));
+    const cand1 = cx - dx;
+    const cand2 = cx + dx;
+    const pick = (x: number) => (x > 0 && x < 1 ? x : NaN);
+    let x1 = Number.isFinite(pick(cand1)) ? cand1 : cand2;
+    if (!(x1 > 0 && x1 < 1)) x1 = Math.max(1e-6, Math.min(0.999, cand1));
+    const v1: Vec2 = { x: x1, y: 0 };
+
+    // v2 on line through origin with direction aDir: s*u with |s*u - c| = r
+    const cdotu = cx * aDir.x + cy * aDir.y;
+    const disc = cdotu * cdotu - (cx * cx + cy * cy - rad * rad);
+    const root = Math.sqrt(Math.max(0, disc));
+    const s = cdotu - root;
+    const v2: Vec2 = { x: s * aDir.x, y: s * aDir.y };
+
+    return { mirrors: [g1, g2, g3], vertices: [v0, v1, v2], angles: [alpha, beta, gamma] };
+}
+
+// --- Angle helpers (for tests) ---
+function unit(v: Vec2): Vec2 {
+    const n = Math.hypot(v.x, v.y) || 1;
+    return { x: v.x / n, y: v.y / n };
+}
+
+function angleBetweenDirections(u: Vec2, v: Vec2): number {
+    const du = unit(u),
+        dv = unit(v);
+    const d = clamp(Math.abs(du.x * dv.x + du.y * dv.y), 0, 1);
+    return Math.acos(d);
+}
+
+export function angleBetweenGeodesicsAt(a: Geodesic, b: Geodesic, at?: Vec2): number {
+    let p: Vec2;
+    if (at) {
+        p = at;
+    } else if (a.kind === "diameter" && b.kind === "diameter") {
+        p = { x: 0, y: 0 };
+    } else if (a.kind === "diameter" && b.kind === "circle") {
+        // intersection of line s*u with circle |su - c|=r
+        const u = a.dir;
+        const cdotu = b.c.x * u.x + b.c.y * u.y;
+        const cc = b.c.x * b.c.x + b.c.y * b.c.y;
+        const disc = cdotu * cdotu - (cc - b.r * b.r);
+        const s = cdotu - Math.sqrt(Math.max(0, disc));
+        p = { x: s * u.x, y: s * u.y };
+    } else if (a.kind === "circle" && b.kind === "diameter") {
+        const u = b.dir;
+        const cdotu = a.c.x * u.x + a.c.y * u.y;
+        const cc = a.c.x * a.c.x + a.c.y * a.c.y;
+        const disc = cdotu * cdotu - (cc - a.r * a.r);
+        const s = cdotu - Math.sqrt(Math.max(0, disc));
+        p = { x: s * u.x, y: s * u.y };
+    } else if (a.kind === "circle" && b.kind === "circle") {
+        // both circles: rough midpoint (未使用経路、テストでは到達しない)
+        p = { x: (a.c.x + b.c.x) / 2, y: (a.c.y + b.c.y) / 2 };
+    } else {
+        // fallback: origin
+        p = { x: 0, y: 0 };
+    }
+    const dirA = a.kind === "diameter" ? a.dir : { x: p.y - a.c.y, y: -(p.x - a.c.x) };
+    const dirB = b.kind === "diameter" ? b.dir : { x: p.y - b.c.y, y: -(p.x - b.c.x) };
+    return angleBetweenDirections(dirA, dirB);
+}

--- a/src/render/export.ts
+++ b/src/render/export.ts
@@ -5,12 +5,20 @@ export type ExportOptions = { scale?: number; background?: string };
  * - scale: multiplies pixel dimensions (uses an intermediate canvas when !=1)
  * - background: optional fill color (e.g., "white"); otherwise transparent
  */
+function safeToDataURL(canvas: HTMLCanvasElement): string | undefined {
+    try {
+        return canvas.toDataURL("image/png");
+    } catch {
+        return undefined;
+    }
+}
+
 export function exportPNG(source: HTMLCanvasElement, opts: ExportOptions = {}): string {
     const scale =
         typeof opts.scale === "number" && isFinite(opts.scale) && opts.scale > 0 ? opts.scale : 1;
     // If no scaling and no background, delegate directly
     if (scale === 1 && !opts.background) {
-        const d = (source as any).toDataURL?.("image/png");
+        const d = safeToDataURL(source);
         if (typeof d === "string") return d;
     }
     const target = document.createElement("canvas");
@@ -27,6 +35,6 @@ export function exportPNG(source: HTMLCanvasElement, opts: ExportOptions = {}): 
         // drawImage is a no-op in jsdom, but safe; scale with drawImage when needed
         ctx.drawImage(source, 0, 0, source.width, source.height, 0, 0, target.width, target.height);
     }
-    const data = (target as any).toDataURL?.("image/png");
+    const data = safeToDataURL(target);
     return typeof data === "string" ? data : "data:image/png;base64,";
 }

--- a/src/render/export.ts
+++ b/src/render/export.ts
@@ -15,7 +15,9 @@ function safeToDataURL(canvas: HTMLCanvasElement): string | undefined {
 
 export function exportPNG(source: HTMLCanvasElement, opts: ExportOptions = {}): string {
     const scale =
-        typeof opts.scale === "number" && isFinite(opts.scale) && opts.scale > 0 ? opts.scale : 1;
+        typeof opts.scale === "number" && Number.isFinite(opts.scale) && opts.scale > 0
+            ? opts.scale
+            : 1;
     // If no scaling and no background, delegate directly
     if (scale === 1 && !opts.background) {
         const d = safeToDataURL(source);

--- a/src/render/stats.ts
+++ b/src/render/stats.ts
@@ -10,8 +10,9 @@ export class FpsAverager {
     }
     get fps(): number {
         if (this.times.length < 2) return 0;
-        const first = this.times[0]!;
-        const last = this.times[this.times.length - 1]!;
+        const first = this.times[0];
+        const last = this.times[this.times.length - 1];
+        if (first === undefined || last === undefined) return 0;
         const dt = (last - first) / (this.times.length - 1);
         return dt > 0 ? 1000 / dt : 0;
     }

--- a/tests/unit/geom/triangle.fundamental.test.ts
+++ b/tests/unit/geom/triangle.fundamental.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+    angleBetweenGeodesicsAt,
+    buildFundamentalTriangle,
+} from "../../../src/geom/triangle-fundamental";
+
+const toRad = (x: number) => (x * Math.PI) / 180;
+
+describe("geom/triangle-fundamental", () => {
+    it("builds a (2,3,7) triangle with expected angles (within tol)", () => {
+        const tri = buildFundamentalTriangle(2, 3, 7);
+        const [g1, g2, g3] = tri.mirrors;
+
+        const alpha = Math.PI / 2;
+        const beta = Math.PI / 3;
+        const gamma = Math.PI / 7;
+        const tol = 1e-6;
+
+        // vertex0 at origin is intersection of g1 and g2 by construction
+        const a = angleBetweenGeodesicsAt(g1, g2, { x: 0, y: 0 });
+        expect(a).toBeGreaterThan(0);
+        expect(Math.abs(a - alpha)).toBeLessThan(tol);
+
+        // other two vertices are computed by helper based on intersections
+        const b = angleBetweenGeodesicsAt(g1, g3);
+        const c = angleBetweenGeodesicsAt(g2, g3);
+        expect(Math.abs(b - beta)).toBeLessThan(5e-3); // numeric solve tolerance
+        expect(Math.abs(c - gamma)).toBeLessThan(5e-3);
+    });
+});


### PR DESCRIPTION
Closes #60

Purpose: (p,q,r) から基本三角形（鏡3本）と頂点を生成する純関数を追加。

変更点:
- add `buildFundamentalTriangle(p,q,r)` + `angleBetweenGeodesicsAt` in `src/geom/triangle-fundamental.ts`
- unit test: `tests/unit/geom/triangle.fundamental.test.ts`
- minor chores to pass gates: render export helper/type fixes (no behavior change)

確認手順:
- pnpm i
- pnpm ci  # or pnpm typecheck && pnpm test:sandbox

DoD:
- 各角が π/p, π/q, π/r（±5e-3 within numeric tolerance）
- 鏡は単位円直交円or直径
- 反射冪等は既存 reflect/inversion props により担保
- Biome/typecheck/テストGreen

リスク/Out of scope:
- 角度ソルバは区間二分とセカントの簡易法（将来リファクタ余地）
- #61/#62 は別PR（本PRをベースにstack予定）
