### PR TITLE
feat(geom): 三鏡群の展開（BFS/重複除去/seed決定性）

### DIFF
--- a/src/geom/triangle-group.ts
+++ b/src/geom/triangle-group.ts
@@ -1,0 +1,76 @@
+import type { FundamentalTriangle } from "./triangle-fundamental";
+import type { Vec2 } from "./types";
+import type { Geodesic } from "./geodesic";
+import { reflectAcrossGeodesic } from "./reflect";
+
+export type TriangleFace = {
+    id: string;
+    verts: [Vec2, Vec2, Vec2];
+    aabb: { min: Vec2; max: Vec2 };
+    word: string;
+};
+
+function aabbOf(verts: [Vec2, Vec2, Vec2]) {
+    const xs = verts.map((v) => v.x);
+    const ys = verts.map((v) => v.y);
+    return {
+        min: { x: Math.min(...xs), y: Math.min(...ys) },
+        max: { x: Math.max(...xs), y: Math.max(...ys) },
+    };
+}
+
+function bary(verts: [Vec2, Vec2, Vec2]): Vec2 {
+    return {
+        x: (verts[0].x + verts[1].x + verts[2].x) / 3,
+        y: (verts[0].y + verts[1].y + verts[2].y) / 3,
+    };
+}
+
+function qkey(p: Vec2, q = 1e-9): string {
+    const qx = Math.round(p.x / q);
+    const qy = Math.round(p.y / q);
+    return `${qx}:${qy}`;
+}
+
+function applyTransform(verts: [Vec2, Vec2, Vec2], mirrors: [Geodesic, Geodesic, Geodesic], idx: 0 | 1 | 2): [Vec2, Vec2, Vec2] {
+    const R = reflectAcrossGeodesic(mirrors[idx]);
+    return [R(verts[0]), R(verts[1]), R(verts[2])];
+}
+
+export function expandTriangleGroup(base: FundamentalTriangle, depth: number, opts?: { maxFaces?: number }) {
+    const mirrors = base.mirrors;
+    const faces: TriangleFace[] = [];
+    const seen = new Set<string>();
+    const queue: { verts: [Vec2, Vec2, Vec2]; word: string }[] = [];
+
+    const pushFace = (verts: [Vec2, Vec2, Vec2], word: string) => {
+        const k = qkey(bary(verts));
+        if (seen.has(k)) return;
+        seen.add(k);
+        const id = `${word}|${k}`;
+        faces.push({ id, verts, aabb: aabbOf(verts), word });
+        queue.push({ verts, word });
+    };
+
+    pushFace(base.vertices, "");
+
+    for (let d = 0; d < depth; d++) {
+        const levelSize = queue.length;
+        for (let i = 0; i < levelSize; i++) {
+            const cur = queue.shift();
+            if (!cur) continue;
+            for (const j of [0, 1, 2] as const) {
+                const w = cur.word + (j + 1).toString();
+                const v = applyTransform(cur.verts as [Vec2, Vec2, Vec2], mirrors, j);
+                pushFace(v, w);
+                if (opts?.maxFaces && faces.length >= opts.maxFaces) break;
+            }
+        }
+        if (opts?.maxFaces && faces.length >= opts.maxFaces) break;
+    }
+
+    // Stable order: by word length then lexicographic word, then id
+    faces.sort((a, b) => a.word.length - b.word.length || (a.word < b.word ? -1 : a.word > b.word ? 1 : a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+
+    return { faces, stats: { depth, total: faces.length, duplicates: seen.size !== faces.length ? faces.length - seen.size : 0 } };
+}

--- a/tests/unit/geom/triangle.group.test.ts
+++ b/tests/unit/geom/triangle.group.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { buildFundamentalTriangle } from "../../../src/geom/triangle-fundamental";
+import { expandTriangleGroup } from "../../../src/geom/triangle-group";
+
+describe("geom/triangle-group", () => {
+    it("expands BFS deterministically without duplicates (depth=2)", () => {
+        const base = buildFundamentalTriangle(2, 3, 7);
+        const { faces, stats } = expandTriangleGroup(base, 2);
+        expect(faces.length).toBeGreaterThanOrEqual(3);
+        // determinism
+        const { faces: faces2 } = expandTriangleGroup(base, 2);
+        expect(faces.map((f) => f.id)).toEqual(faces2.map((f) => f.id));
+        // duplicate-free by id uniqueness
+        const set = new Set(faces.map((f) => f.id));
+        expect(set.size).toBe(faces.length);
+        expect(stats.depth).toBe(2);
+    });
+});


### PR DESCRIPTION
Closes #61

## 目的（Why）
- 背景/課題: 基本三角形と3つの鏡から、反射生成群によるタイル候補（三角形）を決定的に列挙したい。
- 目標: `expandTriangleGroup(base, depth)` で語長BFSにより展開し、重複ゼロ・順序決定性を満たす `TriangleFace[]` を得る。

## 変更点（What）
- 新規: `src/geom/triangle-group.ts`
  - `expandTriangleGroup(base, depth, opts?) → { faces: TriangleFace[]; stats }`
  - `TriangleFace`: `id, verts, aabb, word`
- テスト: `tests/unit/geom/triangle.group.test.ts`
  - depth=2 の決定性（2回実行で id 列一致）と重複ゼロ（Set一致）を検証

### 技術詳細（How）
- 反射: 既存 `reflectAcrossGeodesic` を用い、`s1,s2,s3` を頂点配列に適用。
- BFS: キューで語長順に展開（`word` は [1|2|3] の列）。
- 重複除去: 三角形の重心 bary を量子化（q=1e-9）し Set で排除。
- 安定順序: `word.length → word(辞書順) → id` でソート。
- 統計: `{ depth, total, duplicates }` を返却。

## スクリーンショット / 動作デモ
- なし（数値API）

## 受け入れ条件（DoD）
- [x] 決定性/重複ゼロのユニットテストが緑
- [x] `pnpm typecheck` / `pnpm run test:sandbox` 緑
- [ ] `pnpm lint` 緑（受け入れテストのルール衝突は別Issueで対応）
- [ ] README 最小追記（後続で一括）

## 確認手順（Reviewer 向け）
```bash
pnpm i
pnpm typecheck && pnpm run test:sandbox
```

## リスクとロールバック
- 影響範囲: `geom/*`（群展開）
- リスク: 量子化 q の選定に依存（極近接で誤重複検知の恐れ）。必要に応じ `opts.maxFaces` 等で制御。
- ロールバック: 本ファイル revert で限定。

## Out of Scope（別PR）
- 厳密な braid 関係（(sisj)^{mij} の最短化）
- seed パラメータ化（必要時に拡張）

## 関連 Issue / PR
- Blocked by #60 / Blocks #62 / Refs #57

## 追加メモ
- 並進・回転不変性は今後 property test で拡充予定。
