### PR TITLE
feat(geom): タイリング組立API（TriangleFace[]/AABB/統計/決定順序）

### DIFF
--- a/src/geom/tiling.ts
+++ b/src/geom/tiling.ts
@@ -1,0 +1,12 @@
+import type { FundamentalTriangle } from "./triangle-fundamental";
+import { buildFundamentalTriangle } from "./triangle-fundamental";
+import { expandTriangleGroup, type TriangleFace } from "./triangle-group";
+
+export type TilingParams = { p: number; q: number; r: number; depth: number };
+
+export function buildTiling(params: TilingParams): { faces: TriangleFace[]; stats: { depth: number; total: number } } {
+    const base: FundamentalTriangle = buildFundamentalTriangle(params.p, params.q, params.r);
+    const { faces, stats } = expandTriangleGroup(base, params.depth);
+    return { faces, stats: { depth: stats.depth, total: faces.length } };
+}
+

--- a/tests/unit/geom/tiling.test.ts
+++ b/tests/unit/geom/tiling.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { buildTiling } from "../../../src/geom/tiling";
+
+describe("geom/tiling", () => {
+    it("buildTiling produces deterministic faces and stats", () => {
+        const params = { p: 2, q: 3, r: 7, depth: 2 };
+        const { faces, stats } = buildTiling(params);
+        expect(stats.depth).toBe(2);
+        expect(faces.length).toBeGreaterThan(0);
+        // determinism
+        const { faces: faces2 } = buildTiling(params);
+        expect(faces.map((f) => f.id)).toEqual(faces2.map((f) => f.id));
+        // ordering: word length then lexicographic
+        const words = faces.map((f) => f.word);
+        const sorted = [...words].sort((a, b) => a.length - b.length || (a < b ? -1 : a > b ? 1 : 0));
+        expect(words).toEqual(sorted);
+        // aabb sanity
+        for (const f of faces) {
+            expect(f.aabb.min.x).toBeLessThanOrEqual(f.aabb.max.x);
+            expect(f.aabb.min.y).toBeLessThanOrEqual(f.aabb.max.y);
+        }
+    });
+});
+


### PR DESCRIPTION
Closes #62

## 目的（Why）
- 背景/課題: 群展開の結果を適用し、描画前段として `TriangleFace[]` を決定的順序で返す高位APIが必要。
- 目標: `buildTiling({p,q,r,depth})` を追加し、AABB/統計を付与して返す。

## 変更点（What）
- 新規: `src/geom/tiling.ts`
  - `buildTiling(params) → { faces: TriangleFace[]; stats: { depth, total } }`
- テスト: `tests/unit/geom/tiling.test.ts`
  - 決定性（id 列一致）、順序（語長→辞書順）、AABB 妥当性を検証

### 技術詳細（How）
- `buildFundamentalTriangle` → `expandTriangleGroup` を合成。
- 出力順序は `triangle-group` に準拠（安定ソート）。
- AABB は各 face の `verts` から min/max を算出。

## スクリーンショット / 動作デモ
- なし（数値API）

## 受け入れ条件（DoD）
- [x] 決定性テストが緑
- [x] `pnpm typecheck` / `pnpm run test:sandbox` 緑
- [ ] `pnpm lint` 緑（受け入れテストのルール衝突は別Issueで対応）
- [ ] README 最小追記（WP着地で一括）

## 確認手順（Reviewer 向け）
```bash
pnpm i
pnpm typecheck && pnpm run test:sandbox
```

## リスクとロールバック
- 影響範囲: `geom/*`（タイル組立）
- リスク: depth を大きくすると計算量/メモリ増。
- ロールバック: 本ファイル revert で限定。

## Out of Scope（別PR）
- 描画（Canvas/Storybook）
- 追加統計の拡張（面積/辺長 分布など）

## 関連 Issue / PR
- Blocked by #61 / Refs #57

## 追加メモ
- API名の README 追記は WP 完了時にまとめて行います。
