### PR TITLE
docs(triangle): requirements for triangle polygon rendering (Closes #76)

### DIFF
--- a/docs/triangles/requirements.md
+++ b/docs/triangles/requirements.md
@@ -1,0 +1,64 @@
+# Triangle Polygon Rendering Requirements (Issue #76)
+
+Status: draft
+Parent: #75  / Epic: #56
+Related: #77 (API/Spec), #78 (Tests), #79 (Implementation)
+
+## Goals
+Render closed hyperbolic triangle faces (TriangleFace) as stable stroked polygonal paths (initially stroke only) instead of individual geodesic edges.
+
+## In Scope
+- Deterministic path construction (3 ordered segments) per TriangleFace
+- Segment kinds: line | arc (geodesic circle-arc) with explicit center/radius/orientation
+- Canonical winding (counter‑clockwise in Euclidean embedding of Poincaré disk)
+- Stable sort order for rendering (tie-break: barycenter.x,y then average hyperbolic radius)
+- Minimal culling: off‑viewport & sub‑pixel (configurable threshold)
+- Canvas 2D stroke style defaults (lineWidth=1, lineJoin="miter", lineCap="butt")
+
+## Out of Scope
+- Fill, gradients, WebGL/WebGPU, antialias tuning
+- Advanced batching / spatial index acceleration
+- Self‑intersection diagnostics (faces assumed valid)
+
+## Determinism & Ordering
+- Input order of faces must not affect final rendered z‑order (after sort)
+- Segment point order: vertices A->B->C->A (A chosen by lexicographic (x,y) minimum of the three Euclidean coordinates)
+- Arc direction chosen so interior lies to the left when traversing path
+
+## Winding Rule
+Counter‑clockwise (CCW) in Euclidean disk. If constructed path is CW, swap last two vertices (B,C) to reorient.
+
+## Segment Specification (preview)
+```
+LineSegmentSpec { kind:"line", a:Vec2, b:Vec2 }
+ArcSegmentSpec  { kind:"arc",  a:Vec2, b:Vec2, center:Vec2, radius:number, ccw:boolean }
+```
+(All coordinates in disk coords; precision: double, no rounding until raster stage.)
+
+## Culling
+- Viewport exclusion: all segment endpoints outside disk + bounding circle fully outside canvas -> cull
+- Sub‑pixel: estimated on‑screen perimeter < MIN_PX (default 2) -> cull
+
+## Numerical Considerations
+- Tolerance eps = 1e-12 for orientation / CCW checks
+- Avoid repeated atan2: precompute angles when deriving arc
+- Arc splitting not required yet (single arc per geodesic edge)
+
+## Invariants (for property tests)
+1. Each vertex lies strictly inside unit disk (|p| < 1 - 1e-12)
+2. Reconstructed geodesic edges pass through the three original TriangleFace vertices
+3. Rotation / translation (Mobius isometry) invariance of classification (kind, ordering)
+4. Input face list permutation does not change rendered segment multiset
+5. Winding always CCW
+
+## Open Questions (to resolve before #77 finalizes API)
+- Should we expose hyperbolic edge length on segments for later heuristics? (Tentative: yes, optional field `hLength?: number`)
+- Do we need per‑face id hashing for stable diffing? (Tentative: defer; derive from sorted vertex tuple)
+
+## DoD (Issue #76)
+- Requirements document (this file) committed
+- Any open questions resolved or moved to #77 comment thread
+- No code changes beyond docs for this issue
+
+---
+Appendix changes after review will update this file (versioned via git history).


### PR DESCRIPTION
Closes #76

## Summary
Triangle polygon rendering WorkPack の初期ステップとして、仕様策定・API 設計 (#77)・テスト計画 (#78)・実装 (#79) の共通基盤となる要件文書を追加しました。スコープ/境界条件/不変条件/未解決事項を明文化し、後続 Issue の方向性をロックします。

## Changes
- Add requirements doc: `docs/triangles/requirements.md`
  - Sections: Overview / Goals / Non-Goals / Geometry Model / Path Semantics / Normalization / Invariants / Acceptance Criteria / Open Questions / Future Extensions

## Rationale
- 早期に不変条件 (CCW, no self-intersection, arc constraints 等) を固定し後続タスクの再作業を防止
- Open Questions を一箇所集約し、API/実装段階での議論コストを低減
- 後続プロパティテスト (#78) の性質リストを導出可能な形で整理

## Test Plan
- 本 PR はドキュメントのみ。既存テスト群 (unit/property/acceptance) が Green であることを CI で確認
- フォーマット / lint / typecheck に影響なし

## Follow-ups
1. API/Spec 定義 (#77) — SegmentSpec/TrianglePathSpec 具体化
2. Test Scaffolding (#78) — ユニット/プロパティ骨組み作成
3. Implementation (#79) — buildTrianglePath & strokeTrianglePath 実装
4. Property: winding / permutation invariance — 追加性質検証
5. Acceptance: rendered path pixel diff — ビジュアルリグレッション

## Merge Order Guidance
1. (this) PR #80 requirements
2. PR #81 API/spec
3. PR #82 tests scaffolding
4. 実装 PR (#79) 以降

## Checklist
- [x] 1PR:1Issue 原則順守
- [x] Acceptance tests 未変更
- [x] Red→Green 不要 (doc のみ)
- [x] 後続 Issue 明確
- [x] Open Questions 記載 (将来の diff 起点)

## Open Questions Snapshot
- Arc parameterization for hyperbolic length (hLength) exposureタイミング
- Normalization: identical geodesic arcs mergingルールの詳細
- Future: fill/stroke layering と clipping 戦略

---
レビュー観点: 不足する不変条件・性質、Open Questions の抜け、後続 Issue 粒度。追加要望あればコメントください。