### PR TITLE
feat(render): triangle path spec & stroke stub (Closes #77)

### DIFF
--- a/src/render/trianglePath.ts
+++ b/src/render/trianglePath.ts
@@ -1,0 +1,91 @@
+/*
+ * Triangle path specification (Issue #77)
+ * Parent: #75  Epic: #56
+ */
+import type { Vec2 } from "../geom/types";
+
+export interface LineSegmentSpec {
+    kind: "line";
+    a: Vec2;
+    b: Vec2;
+    // Optional hyperbolic length (future use for sorting / culling heuristics)
+    hLength?: number;
+}
+
+export interface ArcSegmentSpec {
+    kind: "arc";
+    a: Vec2; // start point
+    b: Vec2; // end point
+    center: Vec2; // Euclidean center of supporting circle
+    radius: number; // Euclidean radius (< 1 for interior arcs that are not boundary)
+    ccw: boolean; // true if arc goes counter‑clockwise from a to b
+    hLength?: number;
+}
+
+export type GeodesicSegmentSpec = LineSegmentSpec | ArcSegmentSpec;
+
+export interface TrianglePathSpec {
+    kind: "triangle-path";
+    // Ordered CCW segments (3). Each segment.a must equal previous segment.b (with eps tolerance handled externally)
+    segments: [GeodesicSegmentSpec, GeodesicSegmentSpec, GeodesicSegmentSpec];
+    // Barycenter (Euclidean) cached for stable ordering
+    barycenter: Vec2;
+    // Original face index or hash (if derivable); optional for now
+    faceId?: number | string;
+}
+
+// Construction options (may expand later)
+export interface BuildTrianglePathOptions {
+    ensureCCW?: boolean; // default true
+    computeHyperbolicLengths?: boolean; // default false
+}
+
+// Epsilon for vector equality / orientation checks
+const EPS = 1e-12;
+
+// Helper: approximate barycenter of 3 points
+function barycenter3(a: Vec2, b: Vec2, c: Vec2): Vec2 {
+    return { x: (a.x + b.x + c.x) / 3, y: (a.y + b.y + c.y) / 3 };
+}
+
+// Placeholder: in future we may inject hyperbolic length computation
+function maybeComputeLength(seg: GeodesicSegmentSpec, _opts: BuildTrianglePathOptions): void {
+    if (!("hLength" in seg) || seg.hLength != null) return;
+    // TODO: implement hyperbolic length if requested
+}
+
+export function buildTrianglePath(
+    segments: [GeodesicSegmentSpec, GeodesicSegmentSpec, GeodesicSegmentSpec],
+    opts: BuildTrianglePathOptions = {},
+): TrianglePathSpec {
+    const { ensureCCW = true, computeHyperbolicLengths = false } = opts;
+
+    // Basic validation: connectivity
+    // NOTE: real epsilon/normalization is deferred to calling adapter; here we do minimal checks
+    if (segments.length !== 3) throw new Error("TrianglePath requires exactly 3 segments");
+
+    // Extract points
+    const p0 = segments[0].a;
+    const p1 = segments[0].b;
+    const p2 = segments[1].b; // assuming connectivity a->b, b->c, c->a
+
+    const bc = barycenter3(p0, p1, p2);
+
+    // Orientation (signed area *2)
+    const area2 = (p1.x - p0.x) * (p2.y - p0.y) - (p1.y - p0.y) * (p2.x - p0.x);
+    let orientedSegments = segments;
+    if (ensureCCW && area2 < -EPS) {
+        // Swap second & third segment to flip orientation (simple heuristic)
+        orientedSegments = [segments[0], segments[2], segments[1]];
+    }
+
+    if (computeHyperbolicLengths) {
+        for (const s of orientedSegments) maybeComputeLength(s, opts);
+    }
+
+    return {
+        kind: "triangle-path",
+        segments: orientedSegments,
+        barycenter: bc,
+    };
+}


### PR DESCRIPTION
Closes #77

## Summary
Triangle polygon rendering WorkPack の第2ステップ。要件 (#76) に基づき、三角形パスを構成するセグメント仕様 (Line / Arc / Geodesic) と `TrianglePathSpec`、および後続の描画/構築処理が利用する `buildTrianglePath` / `strokeTrianglePath` の最小スタブを導入しました。まだジオメトリ解決やキャンバス描画ロジックは含めず、型と拡張ポイントのみを固定します。

## Changes
- Add `src/render/trianglePath.ts`
  - Types: `LineSegmentSpec`, `ArcSegmentSpec`, `TrianglePathSpec`
  - Builder stub: `buildTrianglePath(spec)` — returns normalized structure (TBD logic)
- Update `src/render/canvasAdapter.ts`
  - Add `strokeTrianglePath(ctx, path, style)` stub
  - Extend `StrokeStyle` union to include `trianglePath`

## Rationale
- 後続 (#78 tests / #79 impl) が安全に並行可能になるよう、インターフェースを先行確定
- 早期に最小 ABI (関数シグネチャ & 型) を main に載せることで他機能からの参照/差分設計を容易化
- stroke stub により今後の描画戦略 (lineTo vs arcTo / geodesic映射) 分離を明確化

## Test Plan
- 既存テスト群が Green (doc / types only のため実行パス不影響)
- TypeScript typecheck PASS (新規ファイルで循環依存なし)
- Biome lint/format PASS

## Follow-ups
1. Test Scaffolding (#78) — triangle path unit/property skeleton (PR #82)
2. Implementation (#79) — buildTrianglePath: segment resolution & validation
3. Implementation — strokeTrianglePath: Canvas path emission (geodesic arcs)
4. Property Tests — winding, permutation invariance, arc normalization
5. Acceptance — pixel diff for rendered triangle polygon
6. Perf — large batch stroke benchmarking

## Merge Order Guidance
1. PR #80 (requirements) → 本 PR (#81) → PR #82 (tests) → impl (#79)

## Checklist
- [x] 1PR:1Issue 準拠
- [x] Acceptance tests 未変更
- [x] Public API (types/functions) 記録済 (README 追記は実装段階で別 PR)
- [x] Lint / Typecheck / Tests Green
- [x] 後続タスク列挙

## Open Considerations
- Arc representation: center+radius vs implicit geodesic endpoints param — 実装 Issue (#79) で再検討
- Hyperbolic length (hLength) expose タイミング

---
レビュー観点: 型命名の妥当性 / 追加したい最小フィールド / stroke 戦略の前提抜け。コメント歓迎。