### PR TITLE
feat: prepare hybrid Canvas/WebGL pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pnpm ci             # biome ci + typecheck + test:sandbox
 - `(p,q,r)` preset buttons anchor `p` と `q` を固定（Custom でアンカー解除）。
 - `Snap π/n` トグルで `π/n` グリッドへ吸着（on: 分母が自動調整, off: 生の入力値）。
 - `Snap π/n` が有効な場合、双曲条件 `1/p + 1/q + 1/r < 1` を満たすよう未固定の分母を自動調整します。
-- `R` スライダは分母の範囲 `[2, 200]` で安全に操作可能（p,q 固定）。
+- `R` スライダは分母の範囲 `[2, 100]` で安全に操作可能（p,q 固定）。
 - 既存の数値入力はアンカー状態に応じて自動的に無効化/有効化されます。
 
 ### Git Hooks（husky + lint-staged）
@@ -68,6 +68,11 @@ pnpm ci             # biome ci + typecheck + test:sandbox
   - ドローコールをプログラム/状態でバッチしつつ、必要な順序を保持。
 
 この構造により、GLSL への移行は「Specを解釈するWebGLアダプタの追加」で完結し、幾何やビューポートのコードは不変のまま差し替え可能です。
+
+### Rendering Modes
+- 既定では Canvas モードで描画します。
+- ハイブリッド・モード（Canvas UI + WebGL タイル土台）を試す場合は、起動前に `VITE_RENDER_MODE=hybrid pnpm dev` のように環境変数を指定するか、`window.__HP_RENDER_MODE__ = "hybrid"` を設定してからアプリを初期化してください。
+- ハイブリッド・モードでは WebGL 初期化を試み、未対応ブラウザではエラーログを出して Canvas 描画のみを継続します（GLSL 実装は今後追加予定）。
 
 ## リンク
 - docs/ROADMAP.md（中長期の方向性メモ）

--- a/src/geom/triangleSnap.ts
+++ b/src/geom/triangleSnap.ts
@@ -1,34 +1,28 @@
 const DEFAULT_MIN = 2;
 const DEFAULT_MAX = 200;
-const EPS = 1e-12;
+const HYPERBOLIC_EPS = 1e-12;
+
+export type PqrKey = "p" | "q" | "r";
+
+export type TriangleTriple = Record<PqrKey, number>;
 
 export type SnapParameterOptions = {
     nMin?: number;
     nMax?: number;
 };
 
-export type PqrKey = "p" | "q" | "r";
-
-export type TriangleTriple = Record<PqrKey, number>;
-
 export type SnapTriangleOptions = {
+    nMin?: number;
     nMax?: number;
     locked?: Partial<Record<PqrKey, boolean>>;
 };
 
-const HYPERBOLIC_EPS = 1e-12;
-
-/**
- * Snap a parameter interpreted as π/denominator to the nearest π/n grid.
- * Returns the denominator n within [nMin, nMax], preferring the smaller n when ties occur.
- */
 export function snapParameterToPiOverN(value: number, options?: SnapParameterOptions): number {
     const nMin = Math.max(DEFAULT_MIN, Math.floor(options?.nMin ?? DEFAULT_MIN));
     const nMax = Math.max(nMin, Math.floor(options?.nMax ?? DEFAULT_MAX));
     if (!Number.isFinite(value) || value <= 0) {
         return nMin;
     }
-    // Clamp raw denominator into search interval before converting to angle.
     const clamped = Math.min(Math.max(value, nMin), nMax);
     const theta = Math.PI / clamped;
 
@@ -37,12 +31,12 @@ export function snapParameterToPiOverN(value: number, options?: SnapParameterOpt
     for (let n = nMin; n <= nMax; n += 1) {
         const candidateTheta = Math.PI / n;
         const diff = Math.abs(candidateTheta - theta);
-        if (diff + EPS < bestDiff) {
+        if (diff + HYPERBOLIC_EPS < bestDiff) {
             bestDiff = diff;
             bestN = n;
             continue;
         }
-        if (Math.abs(diff - bestDiff) <= EPS && n < bestN) {
+        if (Math.abs(diff - bestDiff) <= HYPERBOLIC_EPS && n < bestN) {
             bestN = n;
         }
     }
@@ -50,8 +44,37 @@ export function snapParameterToPiOverN(value: number, options?: SnapParameterOpt
 }
 
 export const DEFAULT_PI_OVER_N_MAX = DEFAULT_MAX;
+export const HYPERBOLIC_THRESHOLD = 1 - HYPERBOLIC_EPS;
 
-const PQR_KEYS: readonly PqrKey[] = ["p", "q", "r"] as const;
+export function snapTriangleParams(
+    values: TriangleTriple,
+    options?: SnapTriangleOptions,
+): TriangleTriple {
+    const nMin = Math.max(DEFAULT_MIN, Math.floor(options?.nMin ?? DEFAULT_MIN));
+    const nMax = Math.max(nMin, Math.floor(options?.nMax ?? DEFAULT_MAX));
+    const locked = options?.locked ?? {};
+
+    const snapped: TriangleTriple = {
+        p: snapParameterToPiOverN(values.p, { nMin, nMax }),
+        q: snapParameterToPiOverN(values.q, { nMin, nMax }),
+        r: snapParameterToPiOverN(values.r, { nMin, nMax }),
+    };
+
+    const adjustable = (Object.keys(snapped) as PqrKey[]).filter((key) => !locked[key]);
+    if (adjustable.length === 0) {
+        return snapped;
+    }
+
+    let sum = hyperbolicSum(snapped);
+    while (sum >= HYPERBOLIC_THRESHOLD) {
+        const key = nextAdjustableKey(snapped, adjustable, nMax);
+        if (!key) break;
+        snapped[key] += 1;
+        sum = hyperbolicSum(snapped);
+    }
+
+    return snapped;
+}
 
 function hyperbolicSum(triple: TriangleTriple): number {
     return 1 / triple.p + 1 / triple.q + 1 / triple.r;
@@ -74,35 +97,3 @@ function nextAdjustableKey(
     }
     return candidate;
 }
-
-export function snapTriangleParams(
-    values: TriangleTriple,
-    options?: SnapTriangleOptions,
-): TriangleTriple {
-    const nMax = Math.max(DEFAULT_MIN, Math.floor(options?.nMax ?? DEFAULT_MAX));
-    const locked = options?.locked ?? {};
-
-    const snapped: TriangleTriple = {
-        p: snapParameterToPiOverN(values.p, { nMax }),
-        q: snapParameterToPiOverN(values.q, { nMax }),
-        r: snapParameterToPiOverN(values.r, { nMax }),
-    };
-
-    const adjustable = PQR_KEYS.filter((key) => !locked[key]);
-    if (adjustable.length === 0) {
-        return snapped;
-    }
-
-    let sum = hyperbolicSum(snapped);
-    // Increase denominators until we cross into the hyperbolic region or adjustments are exhausted.
-    while (sum >= 1 - HYPERBOLIC_EPS) {
-        const key = nextAdjustableKey(snapped, adjustable, nMax);
-        if (!key) break;
-        snapped[key] += 1;
-        sum = hyperbolicSum(snapped);
-    }
-
-    return snapped;
-}
-
-export const HYPERBOLIC_THRESHOLD = 1 - HYPERBOLIC_EPS;

--- a/src/render/canvasLayers.ts
+++ b/src/render/canvasLayers.ts
@@ -1,0 +1,39 @@
+import { drawCircle, drawLine } from "./canvasAdapter";
+import type { TilePrimitive, TileScene } from "./scene";
+
+export type CanvasTileStyle = {
+    tileStroke?: string;
+    diskStroke?: string;
+    lineWidth?: number;
+};
+
+const DEFAULT_STYLE: Required<CanvasTileStyle> = {
+    tileStroke: "#4a90e2",
+    diskStroke: "#222",
+    lineWidth: 1,
+};
+
+export function renderTileLayer(
+    ctx: CanvasRenderingContext2D,
+    scene: TileScene,
+    style: CanvasTileStyle = {},
+): void {
+    const { tileStroke, diskStroke, lineWidth } = { ...DEFAULT_STYLE, ...style };
+    ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+    drawCircle(ctx, scene.disk, { strokeStyle: diskStroke, lineWidth });
+    for (const primitive of scene.tiles) {
+        drawTilePrimitive(ctx, primitive, { strokeStyle: tileStroke, lineWidth });
+    }
+}
+
+function drawTilePrimitive(
+    ctx: CanvasRenderingContext2D,
+    primitive: TilePrimitive,
+    style: { strokeStyle: string; lineWidth: number },
+): void {
+    if (primitive.kind === "circle") {
+        drawCircle(ctx, primitive.circle, style);
+        return;
+    }
+    drawLine(ctx, primitive.line, style);
+}

--- a/src/render/engine.ts
+++ b/src/render/engine.ts
@@ -1,0 +1,120 @@
+import type { TilingParams } from "../geom/tiling";
+import { attachResize, setCanvasDPR } from "./canvas";
+import { renderTileLayer } from "./canvasLayers";
+import { buildTileScene, type TileScene } from "./scene";
+import type { Viewport } from "./viewport";
+import { createWebGLRenderer, type WebGLRenderer } from "./webglStub";
+
+export type RenderMode = "canvas" | "hybrid";
+
+export interface RenderEngine {
+    render(params: TilingParams): void;
+    dispose(): void;
+    getMode(): RenderMode;
+}
+
+export type RenderEngineOptions = {
+    mode?: RenderMode;
+};
+
+const DEFAULT_MODE: RenderMode = "canvas";
+
+export function detectRenderMode(): RenderMode {
+    const envMode = safeString(readEnvRenderMode());
+    if (isRenderMode(envMode)) return envMode;
+    if (typeof window !== "undefined") {
+        const globalMode = safeString(
+            (window as unknown as { __HP_RENDER_MODE__?: string }).__HP_RENDER_MODE__,
+        );
+        if (isRenderMode(globalMode)) return globalMode;
+    }
+    return DEFAULT_MODE;
+}
+
+export function createRenderEngine(
+    canvas: HTMLCanvasElement,
+    options: RenderEngineOptions = {},
+): RenderEngine {
+    const mode = options.mode ?? detectRenderMode();
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+        throw new Error("Canvas 2D context is required for render engine");
+    }
+
+    const webgl = mode === "hybrid" ? createWebGLRenderer() : null;
+    const resizeHandlers: Array<() => void> = [];
+    let lastParams: TilingParams | null = null;
+    let disposed = false;
+
+    const renderScene = (params: TilingParams) => {
+        if (disposed) return;
+        lastParams = params;
+        setCanvasDPR(canvas);
+        const rect = canvas.getBoundingClientRect();
+        const viewport = computeViewport(rect, canvas);
+        const scene = buildTileScene(params, viewport);
+        renderCanvasLayer(ctx, scene);
+        if (webgl) {
+            syncWebGLCanvas(webgl, canvas);
+            webgl.renderer.render(scene);
+        }
+    };
+
+    resizeHandlers.push(
+        attachResize(canvas, () => {
+            if (!lastParams) return;
+            renderScene(lastParams);
+        }),
+    );
+
+    return {
+        render: renderScene,
+        dispose: () => {
+            disposed = true;
+            for (const disposeHandler of resizeHandlers) disposeHandler();
+            if (webgl) {
+                webgl.renderer.dispose();
+            }
+        },
+        getMode: () => mode,
+    };
+}
+
+function renderCanvasLayer(ctx: CanvasRenderingContext2D, scene: TileScene) {
+    renderTileLayer(ctx, scene);
+}
+
+function computeViewport(rect: DOMRect, canvas: HTMLCanvasElement): Viewport {
+    const width = rect.width || canvas.width || 1;
+    const height = rect.height || canvas.height || 1;
+    const size = Math.min(width, height);
+    const margin = 8;
+    const scale = Math.max(1, size / 2 - margin);
+    return { scale, tx: width / 2, ty: height / 2 };
+}
+
+function syncWebGLCanvas(
+    webgl: { renderer: WebGLRenderer; canvas: HTMLCanvasElement | null },
+    uiCanvas: HTMLCanvasElement,
+) {
+    if (!webgl.canvas) return;
+    webgl.canvas.width = uiCanvas.width;
+    webgl.canvas.height = uiCanvas.height;
+}
+
+function safeString(value: unknown): string | null {
+    return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function isRenderMode(value: string | null): value is RenderMode {
+    return value === "canvas" || value === "hybrid";
+}
+
+function readEnvRenderMode(): string | null {
+    try {
+        const meta = import.meta as unknown as { env?: Record<string, string | undefined> };
+        return meta.env?.VITE_RENDER_MODE ?? null;
+    } catch {
+        return null;
+    }
+}

--- a/src/render/scene.ts
+++ b/src/render/scene.ts
@@ -1,0 +1,50 @@
+import type { Geodesic } from "../geom/geodesic";
+import type { TilingParams } from "../geom/tiling";
+import { buildTiling } from "../geom/tiling";
+import type { TriangleFace } from "../geom/triangle-group";
+import { type CircleSpec, geodesicSpec, type LineSpec, unitDiskSpec } from "./primitives";
+import { facesToEdgeGeodesics } from "./tilingAdapter";
+import type { Viewport } from "./viewport";
+
+export type TilePrimitiveBase = {
+    id: string;
+    faceId: string;
+    faceWord: string;
+    edgeIndex: 0 | 1 | 2;
+    geodesic: Geodesic;
+};
+
+export type TilePrimitive =
+    | (TilePrimitiveBase & { kind: "circle"; circle: CircleSpec })
+    | (TilePrimitiveBase & { kind: "line"; line: LineSpec });
+
+export type TileScene = {
+    disk: CircleSpec;
+    tiles: TilePrimitive[];
+};
+
+function buildTilePrimitives(faces: TriangleFace[], vp: Viewport): TilePrimitive[] {
+    const edges = facesToEdgeGeodesics(faces);
+    return edges.map((edge) => {
+        const spec = geodesicSpec(edge.geodesic, vp);
+        const base: TilePrimitiveBase = {
+            id: `${edge.faceId}:${edge.edgeIndex}`,
+            faceId: edge.faceId,
+            faceWord: edge.faceWord,
+            edgeIndex: edge.edgeIndex,
+            geodesic: edge.geodesic,
+        };
+        if ("r" in spec) {
+            return { ...base, kind: "circle", circle: spec } as TilePrimitive;
+        }
+        return { ...base, kind: "line", line: spec } as TilePrimitive;
+    });
+}
+
+export function buildTileScene(params: TilingParams, vp: Viewport): TileScene {
+    const { faces } = buildTiling(params);
+    return {
+        disk: unitDiskSpec(vp),
+        tiles: buildTilePrimitives(faces, vp),
+    };
+}

--- a/src/render/webglStub.ts
+++ b/src/render/webglStub.ts
@@ -1,0 +1,48 @@
+import type { TileScene } from "./scene";
+
+export interface WebGLRenderer {
+    render(scene: TileScene): void;
+    dispose(): void;
+}
+
+export type WebGLInitResult = {
+    renderer: WebGLRenderer;
+    canvas: HTMLCanvasElement | null;
+};
+
+export function createWebGLRenderer(): WebGLInitResult {
+    const glCanvas = typeof document !== "undefined" ? document.createElement("canvas") : null;
+    const gl = glCanvas ? acquireWebGLContext(glCanvas) : null;
+    if (!gl) {
+        console.error(
+            "[render] WebGL initialisation failed – hybrid renderer running without GL tiles",
+        );
+    }
+    return {
+        canvas: glCanvas,
+        renderer: {
+            render: (scene: TileScene) => {
+                if (!gl) return;
+                // Placeholder: future implementation will upload tile primitives and draw via GLSL.
+                void scene;
+            },
+            dispose: () => {
+                if (!glCanvas) return;
+                // In browsers there is no explicit dispose for WebGL contexts; releasing references is enough.
+                glCanvas.width = 0;
+                glCanvas.height = 0;
+            },
+        },
+    };
+}
+
+function acquireWebGLContext(
+    canvas: HTMLCanvasElement,
+): WebGLRenderingContext | WebGL2RenderingContext | null {
+    const attributes: WebGLContextAttributes = { preserveDrawingBuffer: true, antialias: true };
+    const gl2 = canvas.getContext("webgl2", attributes) as WebGL2RenderingContext | null;
+    if (gl2) return gl2;
+    const gl = canvas.getContext("webgl", attributes) as WebGLRenderingContext | null;
+    if (gl) return gl;
+    return canvas.getContext("experimental-webgl", attributes) as WebGLRenderingContext | null;
+}

--- a/tests/unit/geom/triangleParams.test.ts
+++ b/tests/unit/geom/triangleParams.test.ts
@@ -16,9 +16,9 @@ describe("validateTriangleParams", () => {
         }
     });
 
-    it("allows non-integer inputs when integers are optional", () => {
+    it("allows non-integers when integers are optional", () => {
         const result = validateTriangleParams(
-            { p: 2.5, q: 3.5, r: 7.2 },
+            { p: 2.5, q: 3.2, r: 7.9 },
             { requireIntegers: false },
         );
         expect(result.ok).toBe(true);

--- a/tests/unit/render/engine.test.ts
+++ b/tests/unit/render/engine.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import { createRenderEngine } from "../../../src/render/engine";
+
+function createMockCanvas() {
+    const canvas = document.createElement("canvas");
+    const ctx = {
+        canvas,
+        save: vi.fn(),
+        restore: vi.fn(),
+        beginPath: vi.fn(),
+        arc: vi.fn(),
+        moveTo: vi.fn(),
+        lineTo: vi.fn(),
+        closePath: vi.fn(),
+        stroke: vi.fn(),
+        clearRect: vi.fn(),
+        lineWidth: 1,
+        strokeStyle: "#000",
+        lineJoin: "miter",
+        lineCap: "butt",
+    } as unknown as CanvasRenderingContext2D;
+    Object.defineProperty(canvas, "getContext", {
+        value: vi.fn((kind: string) => (kind === "2d" ? ctx : null)),
+    });
+    Object.defineProperty(canvas, "getBoundingClientRect", {
+        value: () => ({
+            width: 200,
+            height: 200,
+            top: 0,
+            left: 0,
+            right: 200,
+            bottom: 200,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+        }),
+    });
+    return { canvas, ctx };
+}
+
+describe("createRenderEngine", () => {
+    it("renders via canvas mode", () => {
+        const { canvas, ctx } = createMockCanvas();
+        const engine = createRenderEngine(canvas, { mode: "canvas" });
+        engine.render({ p: 2, q: 3, r: 7, depth: 1 });
+        expect(ctx.clearRect).toHaveBeenCalled();
+        engine.dispose();
+    });
+
+    it("initialises hybrid mode and logs WebGL errors when unavailable", () => {
+        const { canvas } = createMockCanvas();
+        const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+        const engine = createRenderEngine(canvas, { mode: "hybrid" });
+        engine.render({ p: 2, q: 3, r: 7, depth: 1 });
+        expect(errorSpy).toHaveBeenCalled();
+        engine.dispose();
+        errorSpy.mockRestore();
+    });
+});

--- a/tests/unit/render/scene.test.ts
+++ b/tests/unit/render/scene.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { buildTileScene } from "../../../src/render/scene";
+import type { Viewport } from "../../../src/render/viewport";
+
+const VIEWPORT: Viewport = { scale: 100, tx: 120, ty: 120 };
+
+describe("buildTileScene", () => {
+    it("returns disk and tile primitives", () => {
+        const scene = buildTileScene({ p: 2, q: 3, r: 7, depth: 1 }, VIEWPORT);
+        expect(scene.disk.r).toBeGreaterThan(0);
+        expect(scene.tiles.length).toBeGreaterThan(0);
+        expect(scene.tiles[0]).toHaveProperty("kind");
+    });
+});

--- a/tests/unit/render/webglStub.test.ts
+++ b/tests/unit/render/webglStub.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from "vitest";
+import type { TileScene } from "../../../src/render/scene";
+import { createWebGLRenderer } from "../../../src/render/webglStub";
+
+const SCENE: TileScene = {
+    disk: { cx: 0, cy: 0, r: 1 },
+    tiles: [],
+};
+
+describe("createWebGLRenderer", () => {
+    it("logs an error when WebGL context is unavailable", () => {
+        const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+        const { renderer } = createWebGLRenderer();
+        expect(errorSpy).toHaveBeenCalled();
+        renderer.render(SCENE);
+        renderer.dispose();
+        errorSpy.mockRestore();
+    });
+});

--- a/tests/unit/ui/app.render.test.tsx
+++ b/tests/unit/ui/app.render.test.tsx
@@ -1,7 +1,48 @@
 import { createRoot } from "react-dom/client";
 import { act } from "react-dom/test-utils";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { App } from "../../../src/ui/App";
+
+const originalGetContext = HTMLCanvasElement.prototype.getContext;
+
+beforeAll(() => {
+    Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+        configurable: true,
+        value: function getContext(kind: string) {
+            if (kind === "2d") {
+                return createMockContext(this as HTMLCanvasElement);
+            }
+            return null;
+        },
+    });
+});
+
+afterAll(() => {
+    Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+        configurable: true,
+        value: originalGetContext,
+    });
+});
+
+function createMockContext(canvas: HTMLCanvasElement): CanvasRenderingContext2D {
+    const context = {
+        canvas,
+        save: vi.fn(),
+        restore: vi.fn(),
+        beginPath: vi.fn(),
+        arc: vi.fn(),
+        moveTo: vi.fn(),
+        lineTo: vi.fn(),
+        closePath: vi.fn(),
+        stroke: vi.fn(),
+        clearRect: vi.fn(),
+        lineWidth: 1,
+        strokeStyle: "#000",
+        lineJoin: "miter" as CanvasLineJoin,
+        lineCap: "butt" as CanvasLineCap,
+    } as Record<string, unknown>;
+    return context as unknown as CanvasRenderingContext2D;
+}
 
 // Minimal render test to ensure #stage canvas exists
 describe("App", () => {


### PR DESCRIPTION
Closes #88

## 目的（Why）
- 背景/課題: 現状の描画処理は Canvas 専用で、将来的な WebGL + GLSL への移行ポイントが整理されていない。
- 目標: UI(Canvas)/タイル(WebGL) のハイブリッド化に備えたレンダリングファサードとデータモデルを整備し、モード切替や失敗時のログ出力を可能にする。

## 変更点（What）
- `render/engine.ts` を追加して、Canvas／Hybrid を切り替えられるレンダリングファサードを実装。
- `render/scene.ts` でタイル描画向けの共通データモデル（TilePrimitive/Disk）を構築し、Canvas レイヤ (`canvasLayers.ts`) で利用。
- WebGL 初期化スタブ (`webglStub.ts`) を導入し、`renderMode="hybrid"` 時に初期化を試みて失敗時にエラーログを出力。
- `App.tsx` をリファクタし、レンダリング処理をエンジンに委譲。プリセット UI / スナップ設定を維持しつつ `Render mode` 表示を追加。
- README にレンダリングモードの切り替え手順を追記し、R スライダ範囲の更新を反映。
- Triangle バリデーションの柔軟化 (`requireIntegers` オプション) とスナップヘルパー (`triangleSnap.ts`) を再導入。
- レンダリングエンジン／シーン／WebGL スタブのユニットテスト、および App レンダーテストを更新。

### 技術詳細（How）
- `detectRenderMode()` で `VITE_RENDER_MODE` もしくは `window.__HP_RENDER_MODE__` を読み、Canvas/Hybrid を選択。
- Hybrid モードで WebGL コンテキスト取得を試み、失敗時は `console.error` を出して Canvas レイヤのみ描画。
- レンダリングは `buildTileScene` から得た `TileScene` を Canvas レイヤ／将来の WebGL レイヤで共有できる設計に統一。
- `validateTriangleParams` に `requireIntegers` オプションを追加し、スナップ OFF 時の非整数入力を許容。
- テストではモック Canvas コンテキストを用意し、エンジン初期化や WebGL 失敗ログを検証。

## スクリーンショット / 動作デモ（任意）
- N/A（UI 変更はレンダリングモード表示の追加のみ）

## 受け入れ条件（DoD）
- [x] 新しいレンダリングファサードが Canvas / Hybrid スタブの切り替えを提供する
- [x] Hybrid モードで WebGL 初期化スタブが呼び出され、失敗時にエラーログを出力
- [x] Canvas モードで既存描画・UI が維持されている
- [x] `pnpm lint && pnpm typecheck && pnpm test:sandbox` が緑（coverage v8）
- [x] README にレンダリングモード切替手順を追記

## 確認手順（Reviewer 向け）
```bash
pnpm i
pnpm lint && pnpm typecheck && pnpm test:sandbox
# モード切替サンプル（任意）
VITE_RENDER_MODE=hybrid pnpm dev
```

## リスクとロールバック
- 影響範囲: レンダリング初期化、(p,q,r) UI、三角形パラメータ検証
- リスク/懸念: レンダリングモード検出に起因する起動時エラーハンドリングの漏れ
- ロールバック指針: `feat/88-hybrid-render` のコミットを revert して従来の Canvas 専用描画に戻す

## Out of Scope（別PR）
- GLSL シェーダおよび実際の WebGL 描画実装
- WebGL 用 Canvas の DOM 配置やパフォーマンス最適化

## 関連 Issue / PR
- Refs #88

## 追加メモ（任意）
- ハイブリッドモードは現時点で Canvas 描画に近い挙動のスタブです。実際の WebGL 実装は後続タスクで拡張予定。
