### PR TITLE
feat: split App.tsx into modular components

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,116 +1,49 @@
-import { type ChangeEvent, useEffect, useRef, useState } from "react";
-import type { TilingParams } from "../geom/tiling";
-import { normalizeDepth, validateTriangleParams } from "../geom/triangleParams";
-import { type PqrKey, snapTriangleParams, type TriangleTriple } from "../geom/triangleSnap";
+import { useEffect, useRef, useState } from "react";
 import { createRenderEngine, detectRenderMode, type RenderEngine } from "../render/engine";
+import { DepthControls } from "./components/DepthControls";
+import { PresetSelector } from "./components/PresetSelector";
+import { SnapControls } from "./components/SnapControls";
+import { StageCanvas } from "./components/StageCanvas";
+import { TriangleParamForm } from "./components/TriangleParamForm";
+import type { TrianglePreset } from "./hooks/useTriangleParams";
+import { useTriangleParams } from "./hooks/useTriangleParams";
 
 const TRIANGLE_N_MAX = 100;
+const INITIAL_PARAMS = { p: 2, q: 3, r: 7, depth: 2 } as const;
+const DEPTH_RANGE = { min: 0, max: 10 } as const;
 
-const PQR_PRESETS = [
+const PQR_PRESETS: TrianglePreset[] = [
     { label: "(3,3,3)", p: 3, q: 3, r: 3 },
-    { label: "(2,4,6)", p: 2, q: 4, r: 6 },
+    { label: "(2,4,4)", p: 2, q: 4, r: 4 },
     { label: "(2,3,6)", p: 2, q: 3, r: 6 },
 ];
 
 export function App(): JSX.Element {
     const canvasRef = useRef<HTMLCanvasElement | null>(null);
-    const [formInputs, setFormInputs] = useState({ p: "2", q: "3", r: "7" });
-    const [params, setParams] = useState<TilingParams>({ p: 2, q: 3, r: 7, depth: 2 });
-    const [paramError, setParamError] = useState<string | null>(null);
-    const [snapEnabled, setSnapEnabled] = useState(true);
-    const [anchor, setAnchor] = useState<{ p: number; q: number } | null>({ p: 2, q: 3 });
-    const [preservePresetDisplay, setPreservePresetDisplay] = useState(false);
-    const [renderMode] = useState(() => detectRenderMode());
     const renderEngineRef = useRef<RenderEngine | null>(null);
-    const depthRange = { min: 0, max: 10 } as const;
-    const rRange = { min: 2, max: TRIANGLE_N_MAX } as const;
-    const parsedR = Number(formInputs.r);
-    const rSliderValue = Number.isFinite(parsedR) ? parsedR : params.r;
-    const rStep = snapEnabled ? 1 : 0.1;
+    const [renderMode] = useState(() => detectRenderMode());
 
-    const handleParamChange = (key: PqrKey) => (event: ChangeEvent<HTMLInputElement>) => {
-        if (anchor && key !== "r") {
-            return;
-        }
-        const { value } = event.target;
-        setFormInputs((prev) => ({ ...prev, [key]: value }));
-    };
-
-    const setFromPreset = (preset: { p: number; q: number; r: number }) => {
-        setAnchor({ p: preset.p, q: preset.q });
-        setPreservePresetDisplay(true);
-        setFormInputs({ p: String(preset.p), q: String(preset.q), r: String(preset.r) });
-    };
-
-    const clearAnchor = () => {
-        setAnchor(null);
-    };
-
-    const updateDepth = (value: number) => {
-        setParams((prev) => {
-            const nextDepth = normalizeDepth(value);
-            if (prev.depth === nextDepth) return prev;
-            return { ...prev, depth: nextDepth };
-        });
-    };
-
-    useEffect(() => {
-        if (!anchor) return;
-        setFormInputs((prev) => {
-            const next = { ...prev, p: String(anchor.p), q: String(anchor.q) };
-            if (prev.p === next.p && prev.q === next.q) {
-                return prev;
-            }
-            return next;
-        });
-    }, [anchor]);
-
-    useEffect(() => {
-        const parsed: TriangleTriple = {
-            p: Number(formInputs.p),
-            q: Number(formInputs.q),
-            r: Number(formInputs.r),
-        };
-
-        const snapped = snapEnabled
-            ? snapTriangleParams(parsed, {
-                  nMax: TRIANGLE_N_MAX,
-                  locked: anchor ? { p: true, q: true } : undefined,
-              })
-            : parsed;
-
-        if (snapEnabled && !preservePresetDisplay) {
-            const nextInputs: Record<PqrKey, string> = {
-                p: String(snapped.p),
-                q: String(snapped.q),
-                r: String(snapped.r),
-            };
-
-            const changed = (["p", "q", "r"] as const).some(
-                (key) => nextInputs[key] !== formInputs[key],
-            );
-            if (changed) {
-                setFormInputs(nextInputs as typeof formInputs);
-                return;
-            }
-        }
-
-        const result = validateTriangleParams(snapped, { requireIntegers: snapEnabled });
-        if (result.ok) {
-            setParams((prev) => {
-                if (prev.p === snapped.p && prev.q === snapped.q && prev.r === snapped.r) {
-                    return prev;
-                }
-                return { ...prev, ...snapped };
-            });
-            setParamError(null);
-            if (preservePresetDisplay) {
-                setPreservePresetDisplay(false);
-            }
-        } else {
-            setParamError(result.errors[0] ?? "Invalid parameters");
-        }
-    }, [formInputs, snapEnabled, anchor, preservePresetDisplay]);
+    const {
+        params,
+        formInputs,
+        anchor,
+        snapEnabled,
+        paramError,
+        rRange,
+        rSliderValue,
+        rStep,
+        depthRange,
+        setParamInput,
+        setFromPreset,
+        clearAnchor,
+        setSnapEnabled: setSnapEnabledState,
+        setRFromSlider,
+        updateDepth,
+    } = useTriangleParams({
+        initialParams: INITIAL_PARAMS,
+        triangleNMax: TRIANGLE_N_MAX,
+        depthRange: DEPTH_RANGE,
+    });
 
     useEffect(() => {
         const canvas = canvasRef.current;
@@ -141,141 +74,36 @@ export function App(): JSX.Element {
         >
             <div style={{ display: "grid", gap: "12px", alignContent: "start" }}>
                 <h2 style={{ margin: 0, fontSize: "1.1rem" }}>Triangle Parameters</h2>
-                <div style={{ display: "grid", gap: "8px" }}>
-                    <div style={{ display: "grid", gap: "4px" }}>
-                        <span style={{ fontWeight: 600 }}>Presets</span>
-                        <div style={{ display: "flex", flexWrap: "wrap", gap: "8px" }}>
-                            {PQR_PRESETS.map((preset) => {
-                                const active =
-                                    !!anchor && anchor.p === preset.p && anchor.q === preset.q;
-                                return (
-                                    <button
-                                        key={preset.label}
-                                        type="button"
-                                        onClick={() => setFromPreset(preset)}
-                                        style={{
-                                            padding: "4px 8px",
-                                            border: active ? "1px solid #4a90e2" : "1px solid #bbb",
-                                            backgroundColor: active ? "#e6f1fc" : "#fff",
-                                            cursor: "pointer",
-                                        }}
-                                    >
-                                        {preset.label}
-                                    </button>
-                                );
-                            })}
-                            <button
-                                type="button"
-                                onClick={clearAnchor}
-                                style={{
-                                    padding: "4px 8px",
-                                    border: "1px solid #bbb",
-                                    cursor: "pointer",
-                                }}
-                            >
-                                Custom
-                            </button>
-                        </div>
-                        <span style={{ fontSize: "0.8rem", color: "#555" }}>
-                            Anchor: {anchor ? `p=${anchor.p}, q=${anchor.q}` : "none"}
-                        </span>
-                    </div>
-                    <label style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-                        <span style={{ fontWeight: 600 }}>Snap π/n</span>
-                        <input
-                            type="checkbox"
-                            checked={snapEnabled}
-                            onChange={(event) => setSnapEnabled(event.target.checked)}
-                        />
-                    </label>
-                    <span style={{ fontSize: "0.8rem", color: "#555" }}>
-                        Render mode: {renderMode}
-                    </span>
-                </div>
-                <div style={{ display: "grid", gap: "8px" }}>
-                    {(["p", "q", "r"] as const).map((key) => {
-                        const isR = key === "r";
-                        return (
-                            <label key={key} style={{ display: "grid", gap: "4px" }}>
-                                <span style={{ fontWeight: 600 }}>{key.toUpperCase()}</span>
-                                <input
-                                    type="number"
-                                    min={2}
-                                    max={isR ? rRange.max : undefined}
-                                    step={isR ? rStep : 1}
-                                    disabled={Boolean(anchor) && key !== "r"}
-                                    value={formInputs[key]}
-                                    onChange={handleParamChange(key)}
-                                />
-                            </label>
-                        );
-                    })}
-                </div>
-                <label style={{ display: "grid", gap: "4px" }}>
-                    <span style={{ fontWeight: 600 }}>R (slider)</span>
-                    <input
-                        type="range"
-                        min={rRange.min}
-                        max={rRange.max}
-                        step={rStep}
-                        value={rSliderValue}
-                        onChange={(event) => {
-                            const numeric = Number(event.target.value);
-                            setFormInputs((prev) => ({ ...prev, r: String(numeric) }));
-                        }}
-                    />
-                    <span style={{ fontSize: "0.8rem", color: "#555" }}>
-                        Range: {rRange.min} – {rRange.max}
-                    </span>
-                </label>
-                <p style={{ margin: 0, color: paramError ? "#c0392b" : "#555" }}>
-                    {paramError ?? "Constraint: 1/p + 1/q + 1/r < 1"}
-                </p>
-                <p style={{ margin: 0, fontSize: "0.85rem", color: "#555" }}>
-                    Current: ({params.p}, {params.q}, {params.r})
-                </p>
-                <div style={{ display: "grid", gap: "8px" }}>
-                    <label style={{ display: "grid", gap: "4px" }}>
-                        <span style={{ fontWeight: 600 }}>Depth (slider)</span>
-                        <input
-                            type="range"
-                            min={depthRange.min}
-                            max={depthRange.max}
-                            step={1}
-                            value={params.depth}
-                            onChange={(event) => updateDepth(Number(event.target.value))}
-                        />
-                    </label>
-                    <label style={{ display: "grid", gap: "4px" }}>
-                        <span style={{ fontWeight: 600 }}>Depth (exact)</span>
-                        <input
-                            type="number"
-                            min={depthRange.min}
-                            max={depthRange.max}
-                            step={1}
-                            value={params.depth}
-                            onChange={(event) => {
-                                const numeric = Number(event.target.value);
-                                if (Number.isFinite(numeric)) {
-                                    updateDepth(numeric);
-                                }
-                            }}
-                        />
-                    </label>
-                    <p style={{ margin: 0, fontSize: "0.85rem", color: "#555" }}>
-                        Depth range: {depthRange.min} – {depthRange.max}
-                    </p>
-                </div>
+                <PresetSelector
+                    presets={PQR_PRESETS}
+                    anchor={anchor}
+                    onSelect={setFromPreset}
+                    onClear={clearAnchor}
+                />
+                <SnapControls
+                    snapEnabled={snapEnabled}
+                    renderMode={renderMode}
+                    onToggle={setSnapEnabledState}
+                />
+                <TriangleParamForm
+                    formInputs={formInputs}
+                    params={params}
+                    anchor={anchor}
+                    paramError={paramError}
+                    rRange={rRange}
+                    rStep={rStep}
+                    rSliderValue={rSliderValue}
+                    onParamChange={setParamInput}
+                    onRSliderChange={setRFromSlider}
+                />
+                <DepthControls
+                    depth={params.depth}
+                    depthRange={depthRange}
+                    onDepthChange={updateDepth}
+                />
             </div>
             <div style={{ display: "grid", placeItems: "center" }}>
-                {/* biome-ignore lint/correctness/useUniqueElementIds: Canvas host id is part of public API */}
-                <canvas
-                    id="stage"
-                    ref={canvasRef}
-                    width={800}
-                    height={600}
-                    style={{ border: "1px solid #ccc" }}
-                />
+                <StageCanvas ref={canvasRef} width={800} height={600} />
             </div>
         </div>
     );

--- a/src/ui/components/DepthControls.tsx
+++ b/src/ui/components/DepthControls.tsx
@@ -1,0 +1,50 @@
+export type DepthControlsProps = {
+    depth: number;
+    depthRange: { min: number; max: number };
+    onDepthChange: (value: number) => void;
+};
+
+export function DepthControls({
+    depth,
+    depthRange,
+    onDepthChange,
+}: DepthControlsProps): JSX.Element {
+    const handleChange = (value: string) => {
+        const numeric = Number(value);
+        if (Number.isFinite(numeric)) {
+            onDepthChange(numeric);
+        }
+    };
+
+    return (
+        <div style={{ display: "grid", gap: "8px" }}>
+            <label style={{ display: "grid", gap: "4px" }}>
+                <span style={{ fontWeight: 600 }}>Depth (slider)</span>
+                <input
+                    type="range"
+                    min={depthRange.min}
+                    max={depthRange.max}
+                    step={1}
+                    value={depth}
+                    onInput={(event) => handleChange(event.currentTarget.value)}
+                    onChange={(event) => handleChange(event.currentTarget.value)}
+                />
+            </label>
+            <label style={{ display: "grid", gap: "4px" }}>
+                <span style={{ fontWeight: 600 }}>Depth (exact)</span>
+                <input
+                    type="number"
+                    min={depthRange.min}
+                    max={depthRange.max}
+                    step={1}
+                    value={depth}
+                    onInput={(event) => handleChange(event.currentTarget.value)}
+                    onChange={(event) => handleChange(event.currentTarget.value)}
+                />
+            </label>
+            <p style={{ margin: 0, fontSize: "0.85rem", color: "#555" }}>
+                Depth range: {depthRange.min} – {depthRange.max}
+            </p>
+        </div>
+    );
+}

--- a/src/ui/components/PresetSelector.tsx
+++ b/src/ui/components/PresetSelector.tsx
@@ -1,0 +1,55 @@
+import type { TrianglePreset } from "../hooks/useTriangleParams";
+
+export type PresetSelectorProps = {
+    presets: TrianglePreset[];
+    anchor: { p: number; q: number } | null;
+    onSelect: (preset: TrianglePreset) => void;
+    onClear: () => void;
+};
+
+export function PresetSelector({
+    presets,
+    anchor,
+    onSelect,
+    onClear,
+}: PresetSelectorProps): JSX.Element {
+    return (
+        <div style={{ display: "grid", gap: "4px" }}>
+            <span style={{ fontWeight: 600 }}>Presets</span>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: "8px" }}>
+                {presets.map((preset) => {
+                    const active = !!anchor && anchor.p === preset.p && anchor.q === preset.q;
+                    return (
+                        <button
+                            key={preset.label}
+                            type="button"
+                            onClick={() => onSelect(preset)}
+                            style={{
+                                padding: "4px 8px",
+                                border: active ? "1px solid #4a90e2" : "1px solid #bbb",
+                                backgroundColor: active ? "#e6f1fc" : "#fff",
+                                cursor: "pointer",
+                            }}
+                        >
+                            {preset.label}
+                        </button>
+                    );
+                })}
+                <button
+                    type="button"
+                    onClick={onClear}
+                    style={{
+                        padding: "4px 8px",
+                        border: "1px solid #bbb",
+                        cursor: "pointer",
+                    }}
+                >
+                    Custom
+                </button>
+            </div>
+            <span style={{ fontSize: "0.8rem", color: "#555" }}>
+                Anchor: {anchor ? `p=${anchor.p}, q=${anchor.q}` : "none"}
+            </span>
+        </div>
+    );
+}

--- a/src/ui/components/SnapControls.tsx
+++ b/src/ui/components/SnapControls.tsx
@@ -1,0 +1,25 @@
+export type SnapControlsProps = {
+    snapEnabled: boolean;
+    renderMode: string;
+    onToggle: (enabled: boolean) => void;
+};
+
+export function SnapControls({
+    snapEnabled,
+    renderMode,
+    onToggle,
+}: SnapControlsProps): JSX.Element {
+    return (
+        <div style={{ display: "grid", gap: "8px" }}>
+            <label style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                <span style={{ fontWeight: 600 }}>Snap π/n</span>
+                <input
+                    type="checkbox"
+                    checked={snapEnabled}
+                    onChange={(event) => onToggle(event.target.checked)}
+                />
+            </label>
+            <span style={{ fontSize: "0.8rem", color: "#555" }}>Render mode: {renderMode}</span>
+        </div>
+    );
+}

--- a/src/ui/components/StageCanvas.tsx
+++ b/src/ui/components/StageCanvas.tsx
@@ -1,0 +1,22 @@
+import { forwardRef } from "react";
+
+export type StageCanvasProps = {
+    width: number;
+    height: number;
+    id?: string;
+};
+
+export const StageCanvas = forwardRef<HTMLCanvasElement, StageCanvasProps>(function StageCanvas(
+    { width, height, id = "stage" },
+    ref,
+) {
+    return (
+        <canvas
+            id={id}
+            ref={ref}
+            width={width}
+            height={height}
+            style={{ border: "1px solid #ccc" }}
+        />
+    );
+});

--- a/src/ui/components/TriangleParamForm.tsx
+++ b/src/ui/components/TriangleParamForm.tsx
@@ -1,0 +1,75 @@
+import type { ChangeEvent } from "react";
+import type { TilingParams } from "../../geom/tiling";
+import type { PqrKey } from "../../geom/triangleSnap";
+
+export type TriangleParamFormProps = {
+    formInputs: Record<PqrKey, string>;
+    params: TilingParams;
+    anchor: { p: number; q: number } | null;
+    paramError: string | null;
+    rRange: { min: number; max: number };
+    rStep: number;
+    rSliderValue: number;
+    onParamChange: (key: PqrKey, value: string) => void;
+    onRSliderChange: (value: number) => void;
+};
+
+export function TriangleParamForm({
+    formInputs,
+    params,
+    anchor,
+    paramError,
+    rRange,
+    rStep,
+    rSliderValue,
+    onParamChange,
+    onRSliderChange,
+}: TriangleParamFormProps): JSX.Element {
+    const handleParamChange = (key: PqrKey) => (event: ChangeEvent<HTMLInputElement>) => {
+        onParamChange(key, event.target.value);
+    };
+
+    return (
+        <div style={{ display: "grid", gap: "8px" }}>
+            {(["p", "q", "r"] as const).map((key) => {
+                const isR = key === "r";
+                return (
+                    <label key={key} style={{ display: "grid", gap: "4px" }}>
+                        <span style={{ fontWeight: 600 }}>{key.toUpperCase()}</span>
+                        <input
+                            type="number"
+                            min={2}
+                            max={isR ? rRange.max : undefined}
+                            step={isR ? rStep : 1}
+                            disabled={Boolean(anchor) && key !== "r"}
+                            value={formInputs[key]}
+                            onInput={handleParamChange(key)}
+                            onChange={handleParamChange(key)}
+                        />
+                    </label>
+                );
+            })}
+            <label style={{ display: "grid", gap: "4px" }}>
+                <span style={{ fontWeight: 600 }}>R (slider)</span>
+                <input
+                    type="range"
+                    min={rRange.min}
+                    max={rRange.max}
+                    step={rStep}
+                    value={rSliderValue}
+                    onInput={(event) => onRSliderChange(Number(event.currentTarget.value))}
+                    onChange={(event) => onRSliderChange(Number(event.currentTarget.value))}
+                />
+                <span style={{ fontSize: "0.8rem", color: "#555" }}>
+                    Range: {rRange.min} – {rRange.max}
+                </span>
+            </label>
+            <p style={{ margin: 0, color: paramError ? "#c0392b" : "#555" }}>
+                {paramError ?? "Constraint: 1/p + 1/q + 1/r < 1"}
+            </p>
+            <p style={{ margin: 0, fontSize: "0.85rem", color: "#555" }}>
+                Current: ({params.p}, {params.q}, {params.r})
+            </p>
+        </div>
+    );
+}

--- a/src/ui/hooks/useTriangleParams.ts
+++ b/src/ui/hooks/useTriangleParams.ts
@@ -1,0 +1,186 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { TilingParams } from "../../geom/tiling";
+import { normalizeDepth, validateTriangleParams } from "../../geom/triangleParams";
+import { type PqrKey, snapTriangleParams, type TriangleTriple } from "../../geom/triangleSnap";
+
+export type TrianglePreset = { label: string; p: number; q: number; r: number };
+
+export type UseTriangleParamsOptions = {
+    initialParams: TilingParams;
+    triangleNMax: number;
+    depthRange: { min: number; max: number };
+};
+
+type FormInputs = Record<PqrKey, string>;
+
+type TriangleAnchor = { p: number; q: number } | null;
+
+export type UseTriangleParamsResult = {
+    params: TilingParams;
+    formInputs: FormInputs;
+    anchor: TriangleAnchor;
+    snapEnabled: boolean;
+    paramError: string | null;
+    rRange: { min: number; max: number };
+    rSliderValue: number;
+    rStep: number;
+    depthRange: { min: number; max: number };
+    setParamInput: (key: PqrKey, value: string) => void;
+    setFromPreset: (preset: TrianglePreset) => void;
+    clearAnchor: () => void;
+    setSnapEnabled: (enabled: boolean) => void;
+    setRFromSlider: (value: number) => void;
+    updateDepth: (value: number) => void;
+};
+
+export function useTriangleParams(options: UseTriangleParamsOptions): UseTriangleParamsResult {
+    const { initialParams, triangleNMax, depthRange } = options;
+    const [params, setParams] = useState<TilingParams>({ ...initialParams });
+    const [formInputs, setFormInputs] = useState<FormInputs>(() => ({
+        p: String(initialParams.p),
+        q: String(initialParams.q),
+        r: String(initialParams.r),
+    }));
+    const [anchor, setAnchor] = useState<TriangleAnchor>({
+        p: initialParams.p,
+        q: initialParams.q,
+    });
+    const [snapEnabled, setSnapEnabledState] = useState(true);
+    const [paramError, setParamError] = useState<string | null>(null);
+    const [preservePresetDisplay, setPreservePresetDisplay] = useState(false);
+
+    const rRange = useMemo(() => ({ min: 2, max: triangleNMax }), [triangleNMax]);
+
+    const setParamInput = useCallback(
+        (key: PqrKey, value: string) => {
+            if (anchor && key !== "r") {
+                return;
+            }
+            setFormInputs((prev) => {
+                if (prev[key] === value) {
+                    return prev;
+                }
+                return { ...prev, [key]: value };
+            });
+        },
+        [anchor],
+    );
+
+    const setFromPreset = useCallback((preset: TrianglePreset) => {
+        setAnchor({ p: preset.p, q: preset.q });
+        setPreservePresetDisplay(true);
+        setFormInputs({ p: String(preset.p), q: String(preset.q), r: String(preset.r) });
+    }, []);
+
+    const clearAnchor = useCallback(() => {
+        setAnchor(null);
+    }, []);
+
+    const setSnapEnabled = useCallback((enabled: boolean) => {
+        setSnapEnabledState(enabled);
+    }, []);
+
+    const setRFromSlider = useCallback((value: number) => {
+        setFormInputs((prev) => {
+            const stringValue = String(value);
+            if (prev.r === stringValue) {
+                return prev;
+            }
+            return { ...prev, r: stringValue };
+        });
+    }, []);
+
+    const updateDepth = useCallback((value: number) => {
+        setParams((prev) => {
+            const nextDepth = normalizeDepth(value);
+            if (prev.depth === nextDepth) {
+                return prev;
+            }
+            return { ...prev, depth: nextDepth };
+        });
+    }, []);
+
+    useEffect(() => {
+        if (!anchor) return;
+        setFormInputs((prev) => {
+            const next = {
+                ...prev,
+                p: String(anchor.p),
+                q: String(anchor.q),
+            };
+            if (prev.p === next.p && prev.q === next.q) {
+                return prev;
+            }
+            return next;
+        });
+    }, [anchor]);
+
+    useEffect(() => {
+        const parsed: TriangleTriple = {
+            p: Number(formInputs.p),
+            q: Number(formInputs.q),
+            r: Number(formInputs.r),
+        };
+
+        const snapped = snapEnabled
+            ? snapTriangleParams(parsed, {
+                  nMax: triangleNMax,
+                  locked: anchor ? { p: true, q: true } : undefined,
+              })
+            : parsed;
+
+        if (snapEnabled && !preservePresetDisplay) {
+            const nextInputs: FormInputs = {
+                p: String(snapped.p),
+                q: String(snapped.q),
+                r: String(snapped.r),
+            };
+            const changed = (["p", "q", "r"] as const).some(
+                (key) => nextInputs[key] !== formInputs[key],
+            );
+            if (changed) {
+                setFormInputs(nextInputs);
+                return;
+            }
+        }
+
+        const validation = validateTriangleParams(snapped, {
+            requireIntegers: snapEnabled,
+        });
+        if (validation.ok) {
+            setParams((prev) => {
+                if (prev.p === snapped.p && prev.q === snapped.q && prev.r === snapped.r) {
+                    return prev;
+                }
+                return { ...prev, ...snapped };
+            });
+            setParamError(null);
+            if (preservePresetDisplay) {
+                setPreservePresetDisplay(false);
+            }
+        } else {
+            setParamError(validation.errors[0] ?? "Invalid parameters");
+        }
+    }, [formInputs, snapEnabled, anchor, triangleNMax, preservePresetDisplay]);
+
+    const parsedR = Number(formInputs.r);
+    const rSliderValue = Number.isFinite(parsedR) ? parsedR : params.r;
+
+    return {
+        params,
+        formInputs,
+        anchor,
+        snapEnabled,
+        paramError,
+        rRange,
+        rSliderValue,
+        rStep: snapEnabled ? 1 : 0.1,
+        depthRange,
+        setParamInput,
+        setFromPreset,
+        clearAnchor,
+        setSnapEnabled,
+        setRFromSlider,
+        updateDepth,
+    };
+}

--- a/tests/unit/ui/components.test.tsx
+++ b/tests/unit/ui/components.test.tsx
@@ -1,0 +1,148 @@
+import { act, createRef } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, it, vi } from "vitest";
+import type { PqrKey } from "../../../src/geom/triangleSnap";
+import { DepthControls } from "../../../src/ui/components/DepthControls";
+import { PresetSelector } from "../../../src/ui/components/PresetSelector";
+import { SnapControls } from "../../../src/ui/components/SnapControls";
+import { StageCanvas } from "../../../src/ui/components/StageCanvas";
+import { TriangleParamForm } from "../../../src/ui/components/TriangleParamForm";
+import type { TrianglePreset } from "../../../src/ui/hooks/useTriangleParams";
+
+const globalActFlag = globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean };
+globalActFlag.IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("UI components", () => {
+    it("calls handlers when preset buttons are clicked", () => {
+        const presets: TrianglePreset[] = [
+            { label: "(3,3,3)", p: 3, q: 3, r: 3 },
+            { label: "(2,3,7)", p: 2, q: 3, r: 7 },
+        ];
+        const onSelect = vi.fn();
+        const onClear = vi.fn();
+        const container = document.createElement("div");
+        const root = createRoot(container);
+
+        act(() => {
+            root.render(
+                <PresetSelector
+                    presets={presets}
+                    anchor={{ p: 3, q: 3 }}
+                    onSelect={onSelect}
+                    onClear={onClear}
+                />,
+            );
+        });
+
+        const buttons = Array.from(container.querySelectorAll("button"));
+        expect(buttons).toHaveLength(3);
+        act(() => {
+            buttons[0].click();
+        });
+        expect(onSelect).toHaveBeenCalledWith(presets[0]);
+        act(() => {
+            buttons[2].click();
+        });
+        expect(onClear).toHaveBeenCalledTimes(1);
+
+        act(() => {
+            root.unmount();
+        });
+    });
+
+    it("toggles snap control checkbox", () => {
+        const onToggle = vi.fn();
+        const container = document.createElement("div");
+        const root = createRoot(container);
+        act(() => {
+            root.render(<SnapControls snapEnabled renderMode="webgl" onToggle={onToggle} />);
+        });
+        const checkbox = container.querySelector("input[type=checkbox]") as HTMLInputElement;
+        expect(checkbox).not.toBeNull();
+        act(() => {
+            checkbox.click();
+        });
+        expect(onToggle).toHaveBeenCalledWith(false);
+        act(() => {
+            root.unmount();
+        });
+    });
+
+    it("forwards input changes in triangle form", () => {
+        const onParamChange = vi.fn();
+        const onSlider = vi.fn();
+        const container = document.createElement("div");
+        const root = createRoot(container);
+        act(() => {
+            root.render(
+                <TriangleParamForm
+                    formInputs={{ p: "2", q: "3", r: "7" }}
+                    params={{ p: 2, q: 3, r: 7, depth: 2 }}
+                    anchor={null}
+                    paramError={null}
+                    rRange={{ min: 2, max: 10 }}
+                    rStep={1}
+                    rSliderValue={7}
+                    onParamChange={onParamChange}
+                    onRSliderChange={onSlider}
+                />,
+            );
+        });
+        const inputs = Array.from(container.querySelectorAll("input[type=number]"));
+        expect(inputs).toHaveLength(3);
+        const pInput = inputs[0];
+        act(() => {
+            (pInput as HTMLInputElement).value = "4";
+            pInput.dispatchEvent(new Event("input", { bubbles: true }));
+        });
+        expect(onParamChange).toHaveBeenCalledWith("p" as PqrKey, "4");
+
+        const slider = container.querySelector("input[type=range]") as HTMLInputElement;
+        act(() => {
+            slider.value = "8";
+            slider.dispatchEvent(new Event("input", { bubbles: true }));
+        });
+        expect(onSlider).toHaveBeenCalledWith(8);
+
+        act(() => {
+            root.unmount();
+        });
+    });
+
+    it("renders depth controls and propagates changes", () => {
+        const onDepth = vi.fn();
+        const container = document.createElement("div");
+        const root = createRoot(container);
+        act(() => {
+            root.render(
+                <DepthControls
+                    depth={2}
+                    depthRange={{ min: 0, max: 10 }}
+                    onDepthChange={onDepth}
+                />,
+            );
+        });
+        const slider = container.querySelector("input[type=range]") as HTMLInputElement;
+        act(() => {
+            slider.value = "4";
+            slider.dispatchEvent(new Event("input", { bubbles: true }));
+        });
+        expect(onDepth).toHaveBeenCalledWith(4);
+        act(() => {
+            root.unmount();
+        });
+    });
+
+    it("exposes canvas ref in StageCanvas", () => {
+        const ref = createRef<HTMLCanvasElement>();
+        const container = document.createElement("div");
+        const root = createRoot(container);
+        act(() => {
+            root.render(<StageCanvas ref={ref} width={800} height={600} />);
+        });
+        expect(ref.current).toBeInstanceOf(HTMLCanvasElement);
+        act(() => {
+            root.unmount();
+        });
+    });
+});

--- a/tests/unit/ui/useTriangleParams.test.tsx
+++ b/tests/unit/ui/useTriangleParams.test.tsx
@@ -1,0 +1,125 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, it } from "vitest";
+import type { TrianglePreset } from "../../../src/ui/hooks/useTriangleParams";
+import {
+    type UseTriangleParamsOptions,
+    useTriangleParams,
+} from "../../../src/ui/hooks/useTriangleParams";
+
+const globalActFlag = globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean };
+globalActFlag.IS_REACT_ACT_ENVIRONMENT = true;
+
+type HookResult = ReturnType<typeof useTriangleParams>;
+
+type HookHarness = {
+    current: HookResult;
+    update: (callback: (result: HookResult) => void) => void;
+    cleanup: () => void;
+};
+
+const DEFAULT_OPTIONS: UseTriangleParamsOptions = {
+    initialParams: { p: 2, q: 3, r: 7, depth: 2 },
+    triangleNMax: 100,
+    depthRange: { min: 0, max: 10 },
+};
+
+function renderHook(options?: Partial<UseTriangleParamsOptions>): HookHarness {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    let current: HookResult | null = null;
+
+    function HookWrapper({ opts }: { opts: UseTriangleParamsOptions }) {
+        current = useTriangleParams(opts);
+        return null;
+    }
+
+    const merged: UseTriangleParamsOptions = { ...DEFAULT_OPTIONS, ...options };
+    act(() => {
+        root.render(<HookWrapper opts={merged} />);
+    });
+
+    if (!current) {
+        throw new Error("Hook did not initialize");
+    }
+
+    return {
+        get current() {
+            if (!current) throw new Error("Hook result unavailable");
+            return current;
+        },
+        update: (callback) => {
+            act(() => {
+                if (!current) throw new Error("Hook result unavailable");
+                callback(current);
+            });
+        },
+        cleanup: () => {
+            act(() => {
+                root.unmount();
+            });
+            document.body.removeChild(container);
+        },
+    };
+}
+
+describe("useTriangleParams", () => {
+    it("updates parameters when inputs change", () => {
+        const harness = renderHook();
+        harness.update((state) => {
+            state.clearAnchor();
+        });
+        harness.update((state) => {
+            state.setParamInput("p", "3");
+            state.setParamInput("q", "7");
+            state.setParamInput("r", "9");
+        });
+        expect(harness.current.params).toMatchObject({ p: 3, q: 7, r: 9 });
+        harness.cleanup();
+    });
+
+    it("locks p and q when anchor is set", () => {
+        const harness = renderHook();
+        const preset: TrianglePreset = { label: "(3,3,3)", p: 3, q: 3, r: 3 };
+        harness.update((state) => {
+            state.setFromPreset(preset);
+            state.setParamInput("p", "5");
+        });
+        expect(harness.current.formInputs.p).toBe("3");
+        harness.cleanup();
+    });
+
+    it("emits validation errors when snap is disabled and the triple is not hyperbolic", () => {
+        const harness = renderHook();
+        harness.update((state) => {
+            state.clearAnchor();
+        });
+        harness.update((state) => {
+            state.setSnapEnabled(false);
+            state.setParamInput("p", "2");
+            state.setParamInput("q", "2");
+            state.setParamInput("r", "2");
+        });
+        expect(harness.current.paramError).toContain("must be < 1");
+        harness.cleanup();
+    });
+
+    it("uses fractional step when snap is disabled", () => {
+        const harness = renderHook();
+        harness.update((state) => {
+            state.setSnapEnabled(false);
+        });
+        expect(harness.current.rStep).toBeCloseTo(0.1);
+        harness.cleanup();
+    });
+
+    it("normalizes depth updates", () => {
+        const harness = renderHook();
+        harness.update((state) => {
+            state.updateDepth(4.6);
+        });
+        expect(harness.current.params.depth).toBe(5);
+        harness.cleanup();
+    });
+});


### PR DESCRIPTION
Closes #92

## 目的（Why）
- 背景/課題: App.tsx が状態管理と UI を一枚に抱えており、拡張時の影響範囲が読みにくかった
- 目標: 主要 UI セクションを責務ごとのコンポーネント／フックに分割し、再利用性とテスト容易性を高める

## 変更点（What）
- PresetSelector/SnapControls/TriangleParamForm/DepthControls/StageCanvas の UI コンポーネントを新設
- triangle 入力処理を useTriangleParams フックに集約し、App.tsx から不要な状態と副作用を除去
- 新規コンポーネントとフックのユニットテストを追加し、フォーム入力やバリデーションをカバー

### 技術詳細（How）
- useTriangleParams でアンカー制御・スナップ・バリデーション・深さ正規化を一元管理し、呼び出し側は純粋なハンドラを受け取る
- UI コンポーネントは制御プロップのみを受け取るプレゼンテーショナル構成にし、stage canvas は forwardRef で公開 API を維持
- React 18 の act 警告対策としてテスト環境に IS_REACT_ACT_ENVIRONMENT フラグを設定

## スクリーンショット / 動作デモ（任意）
- なし

## 受け入れ条件（DoD）
- [x] 目的を満たすユーザーストーリーが確認できる
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test -- --run --pool=threads --poolOptions.threads.singleThread --no-file-parallelism`
- [ ] README/Docs/Storybook（該当時）が更新されている
- [x] アクセシビリティ: ラベル/フォーカス/キーボードが機能し重大違反なし

## 確認手順（Reviewer 向け）
```bash
pnpm i
pnpm lint && pnpm typecheck && pnpm run test:sandbox
```

## リスクとロールバック
- 影響範囲: UI/App レイヤー（プリセット選択・スナップ設定・キャンバス描画）
- リスク/懸念: フックを介した状態遷移にバグがあると UI 全体が動かなくなる可能性
- ロールバック指針: この PR のリバートで単一ファイル構成に戻す

## Out of Scope（別PR）
- Storybook 整備やスタイル微調整

## 関連 Issue / PR
- Refs #92

## 追加メモ（任意）
- なし
