### PR TITLE
feat: add euclidean mode scenes and isolate presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ pnpm ci             # biome ci + typecheck + test:sandbox
 
 この構造により、GLSL への移行は「Specを解釈するWebGLアダプタの追加」で完結し、幾何やビューポートのコードは不変のまま差し替え可能です。
 
+### Geometry Modes
+- 左ペインの「Geometry Mode」で Hyperbolic / Euclidean を切替えられます。
+- Euclidean モードでは (3,3,3) / (2,4,4) / (2,3,6) など `1/p + 1/q + 1/r = 1` を満たす三角群を対象に、三本の半平面鏡（オフセット＋単位法線）を SDF に渡して描画します。
+- 条件から外れた値を入力した場合は警告を表示し、必要に応じて自動的に `(3,3,3)` プリセットへ戻ります。
+
 ### Rendering Modes
 - 既定では Canvas モードで描画します。
 - ハイブリッド・モード（Canvas UI + WebGL タイル土台）を試す場合は、起動前に `VITE_RENDER_MODE=hybrid pnpm dev` のように環境変数を指定するか、`window.__HP_RENDER_MODE__ = "hybrid"` を設定してからアプリを初期化してください。

--- a/src/geom/euclideanTriangle.ts
+++ b/src/geom/euclideanTriangle.ts
@@ -1,0 +1,69 @@
+import type { HalfPlane } from "./halfPlane";
+import { normalizeHalfPlane } from "./halfPlane";
+import type { Vec2 } from "./types";
+
+export type EuclideanTriangle = {
+    mirrors: [HalfPlane, HalfPlane, HalfPlane];
+    vertices: [Vec2, Vec2, Vec2];
+    angles: [number, number, number];
+};
+
+const SUM_TOL = 1e-6;
+
+export function buildEuclideanTriangle(p: number, q: number, r: number): EuclideanTriangle {
+    if (!(p > 1 && q > 1 && r > 1)) {
+        throw new Error("(p,q,r) must all exceed 1 for Euclidean mode");
+    }
+    const alpha = Math.PI / p;
+    const beta = Math.PI / q;
+    const gamma = Math.PI / r;
+    const angleSum = alpha + beta + gamma;
+    if (Math.abs(angleSum - Math.PI) > SUM_TOL) {
+        throw new Error("Angles do not form a Euclidean triangle (π sum constraint)");
+    }
+
+    // Law of sines with c (between v0 and v1) normalized to 1
+    const sinGamma = Math.sin(gamma);
+    if (!(sinGamma > 0)) {
+        throw new Error("Invalid (p,q,r): degenerate Euclidean triangle");
+    }
+    const b = Math.sin(beta) / sinGamma; // length AC
+
+    const v0: Vec2 = { x: 0, y: 0 };
+    const v1: Vec2 = { x: 1, y: 0 };
+    const v2: Vec2 = { x: b * Math.cos(alpha), y: b * Math.sin(alpha) };
+
+    const center: Vec2 = {
+        x: (v0.x + v1.x + v2.x) / 3,
+        y: (v0.y + v1.y + v2.y) / 3,
+    };
+
+    const mirrors: [HalfPlane, HalfPlane, HalfPlane] = [
+        createMirror(v1, v2, center),
+        createMirror(v0, v2, center),
+        createMirror(v0, v1, center),
+    ];
+
+    return {
+        mirrors,
+        vertices: [v0, v1, v2],
+        angles: [alpha, beta, gamma],
+    };
+}
+
+function createMirror(a: Vec2, b: Vec2, interior: Vec2): HalfPlane {
+    const dir = { x: b.x - a.x, y: b.y - a.y };
+    const normal = { x: dir.y, y: -dir.x };
+    const plane = normalizeHalfPlane({
+        normal,
+        offset: -(normal.x * a.x + normal.y * a.y),
+    });
+    const value = plane.normal.x * interior.x + plane.normal.y * interior.y + plane.offset;
+    if (value < 0) {
+        return plane;
+    }
+    return {
+        normal: { x: -plane.normal.x, y: -plane.normal.y },
+        offset: -plane.offset,
+    };
+}

--- a/src/geom/geodesic.ts
+++ b/src/geom/geodesic.ts
@@ -3,7 +3,8 @@ import { defaultTol, tolValue } from "./types";
 
 export type GeodesicCircle = { kind: "circle"; c: Vec2; r: number };
 export type GeodesicDiameter = { kind: "diameter"; dir: Vec2 };
-export type Geodesic = GeodesicCircle | GeodesicDiameter;
+export type GeodesicHalfPlane = { kind: "halfPlane"; normal: Vec2; offset: number };
+export type Geodesic = GeodesicCircle | GeodesicDiameter | GeodesicHalfPlane;
 
 function isOpposite(a: Vec2, b: Vec2): boolean {
     // a ≈ -b  <=>  |a + b| ≈ 0

--- a/src/geom/halfPlane.ts
+++ b/src/geom/halfPlane.ts
@@ -1,0 +1,48 @@
+import type { GeodesicHalfPlane } from "./geodesic";
+import type { Transform2D } from "./reflect";
+import type { Vec2 } from "./types";
+
+export type HalfPlane = {
+    normal: Vec2;
+    offset: number;
+};
+
+const EPS = 1e-12;
+
+export function normalizeHalfPlane(plane: HalfPlane): HalfPlane {
+    const { normal, offset } = plane;
+    const len = Math.hypot(normal.x, normal.y);
+    if (!(len > EPS)) {
+        throw new Error("Half-plane normal must be non-zero");
+    }
+    if (Math.abs(len - 1) <= EPS) {
+        return plane;
+    }
+    const inv = 1 / len;
+    return {
+        normal: { x: normal.x * inv, y: normal.y * inv },
+        offset: offset * inv,
+    };
+}
+
+export function reflectAcrossHalfPlane(plane: HalfPlane): Transform2D {
+    const unit = normalizeHalfPlane(plane);
+    return (point) => {
+        const dot = unit.normal.x * point.x + unit.normal.y * point.y + unit.offset;
+        const scale = 2 * dot;
+        return {
+            x: point.x - scale * unit.normal.x,
+            y: point.y - scale * unit.normal.y,
+        };
+    };
+}
+
+export function evaluateHalfPlane(plane: HalfPlane, point: Vec2): number {
+    const unit = normalizeHalfPlane(plane);
+    return unit.normal.x * point.x + unit.normal.y * point.y + unit.offset;
+}
+
+export function toGeodesicHalfPlane(plane: HalfPlane): GeodesicHalfPlane {
+    const unit = normalizeHalfPlane(plane);
+    return { kind: "halfPlane", normal: unit.normal, offset: unit.offset };
+}

--- a/src/geom/reflect.ts
+++ b/src/geom/reflect.ts
@@ -1,4 +1,5 @@
 import type { Geodesic } from "./geodesic";
+import { reflectAcrossHalfPlane } from "./halfPlane";
 import { invertInCircle } from "./inversion";
 import type { Vec2 } from "./types";
 
@@ -18,6 +19,9 @@ function reflectAcrossDiameter(dirIn: Vec2): Transform2D {
 export function reflectAcrossGeodesic(g: Geodesic): Transform2D {
     if (g.kind === "diameter") {
         return reflectAcrossDiameter(g.dir);
+    }
+    if (g.kind === "halfPlane") {
+        return reflectAcrossHalfPlane({ normal: g.normal, offset: g.offset });
     }
     // circle geodesic: Euclidean inversion in the orthogonal circle
     return (p: Vec2): Vec2 => invertInCircle(p, { c: g.c, r: g.r });

--- a/src/geom/triangle-fundamental.ts
+++ b/src/geom/triangle-fundamental.ts
@@ -232,6 +232,9 @@ function angleBetweenDirections(u: Vec2, v: Vec2): number {
 
 export function angleBetweenGeodesicsAt(a: Geodesic, b: Geodesic, at?: Vec2): number {
     let p: Vec2;
+    if (a.kind === "halfPlane" || b.kind === "halfPlane") {
+        throw new Error("Half-plane geodesics are not supported in hyperbolic angle evaluation");
+    }
     if (at) {
         p = at;
     } else if (a.kind === "diameter" && b.kind === "diameter") {

--- a/src/render/canvasLayers.ts
+++ b/src/render/canvasLayers.ts
@@ -5,12 +5,14 @@ export type CanvasTileStyle = {
     tileStroke?: string;
     diskStroke?: string;
     lineWidth?: number;
+    drawDisk?: boolean;
 };
 
 const DEFAULT_STYLE: Required<CanvasTileStyle> = {
     tileStroke: "#4a90e2",
     diskStroke: "#222",
     lineWidth: 1,
+    drawDisk: true,
 };
 
 export function renderTileLayer(
@@ -18,9 +20,11 @@ export function renderTileLayer(
     scene: TileScene,
     style: CanvasTileStyle = {},
 ): void {
-    const { tileStroke, diskStroke, lineWidth } = { ...DEFAULT_STYLE, ...style };
+    const { tileStroke, diskStroke, lineWidth, drawDisk } = { ...DEFAULT_STYLE, ...style };
     ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
-    drawCircle(ctx, scene.disk, { strokeStyle: diskStroke, lineWidth });
+    if (drawDisk) {
+        drawCircle(ctx, scene.disk, { strokeStyle: diskStroke, lineWidth });
+    }
     for (const primitive of scene.tiles) {
         drawTilePrimitive(ctx, primitive, { strokeStyle: tileStroke, lineWidth });
     }

--- a/src/render/canvasLayers.ts
+++ b/src/render/canvasLayers.ts
@@ -1,5 +1,5 @@
 import { drawCircle, drawLine } from "./canvasAdapter";
-import type { GeodesicPrimitive, HyperbolicScene } from "./scene";
+import type { GeodesicPrimitive, RenderScene } from "./scene";
 
 export type CanvasTileStyle = {
     tileStroke?: string;
@@ -17,15 +17,16 @@ const DEFAULT_STYLE: Required<CanvasTileStyle> = {
 
 export function renderTileLayer(
     ctx: CanvasRenderingContext2D,
-    scene: HyperbolicScene,
+    scene: RenderScene,
     style: CanvasTileStyle = {},
 ): void {
     const { tileStroke, diskStroke, lineWidth, drawDisk } = { ...DEFAULT_STYLE, ...style };
     ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
-    if (drawDisk) {
+    const shouldDrawDisk = drawDisk ?? scene.geometry === "hyperbolic";
+    if (shouldDrawDisk && scene.geometry === "hyperbolic") {
         drawCircle(ctx, scene.disk, { strokeStyle: diskStroke, lineWidth });
     }
-    for (const primitive of scene.tiles) {
+    for (const primitive of scene.geodesics) {
         drawGeodesicPrimitive(ctx, primitive, { strokeStyle: tileStroke, lineWidth });
     }
 }

--- a/src/render/canvasLayers.ts
+++ b/src/render/canvasLayers.ts
@@ -8,21 +8,17 @@ export type CanvasTileStyle = {
     drawDisk?: boolean;
 };
 
-const DEFAULT_STYLE: Required<CanvasTileStyle> = {
-    tileStroke: "#4a90e2",
-    diskStroke: "#222",
-    lineWidth: 1,
-    drawDisk: true,
-};
-
 export function renderTileLayer(
     ctx: CanvasRenderingContext2D,
     scene: RenderScene,
     style: CanvasTileStyle = {},
 ): void {
-    const { tileStroke, diskStroke, lineWidth, drawDisk } = { ...DEFAULT_STYLE, ...style };
+    const tileStroke = style.tileStroke ?? "#4a90e2";
+    const diskStroke = style.diskStroke ?? "#222";
+    const lineWidth = style.lineWidth ?? 1;
+    const drawDiskOption = style.drawDisk;
     ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
-    const shouldDrawDisk = drawDisk ?? scene.geometry === "hyperbolic";
+    const shouldDrawDisk = drawDiskOption ?? scene.geometry === "hyperbolic";
     if (shouldDrawDisk && scene.geometry === "hyperbolic") {
         drawCircle(ctx, scene.disk, { strokeStyle: diskStroke, lineWidth });
     }

--- a/src/render/canvasLayers.ts
+++ b/src/render/canvasLayers.ts
@@ -1,5 +1,5 @@
 import { drawCircle, drawLine } from "./canvasAdapter";
-import type { TilePrimitive, TileScene } from "./scene";
+import type { GeodesicPrimitive, HyperbolicScene } from "./scene";
 
 export type CanvasTileStyle = {
     tileStroke?: string;
@@ -17,7 +17,7 @@ const DEFAULT_STYLE: Required<CanvasTileStyle> = {
 
 export function renderTileLayer(
     ctx: CanvasRenderingContext2D,
-    scene: TileScene,
+    scene: HyperbolicScene,
     style: CanvasTileStyle = {},
 ): void {
     const { tileStroke, diskStroke, lineWidth, drawDisk } = { ...DEFAULT_STYLE, ...style };
@@ -26,13 +26,13 @@ export function renderTileLayer(
         drawCircle(ctx, scene.disk, { strokeStyle: diskStroke, lineWidth });
     }
     for (const primitive of scene.tiles) {
-        drawTilePrimitive(ctx, primitive, { strokeStyle: tileStroke, lineWidth });
+        drawGeodesicPrimitive(ctx, primitive, { strokeStyle: tileStroke, lineWidth });
     }
 }
 
-function drawTilePrimitive(
+function drawGeodesicPrimitive(
     ctx: CanvasRenderingContext2D,
-    primitive: TilePrimitive,
+    primitive: GeodesicPrimitive,
     style: { strokeStyle: string; lineWidth: number },
 ): void {
     if (primitive.kind === "circle") {

--- a/src/render/engine.ts
+++ b/src/render/engine.ts
@@ -2,7 +2,7 @@ import type { HalfPlane } from "../geom/halfPlane";
 import type { TilingParams } from "../geom/tiling";
 import { attachResize, setCanvasDPR } from "./canvas";
 import { type CanvasTileStyle, renderTileLayer } from "./canvasLayers";
-import { buildHalfPlaneScene, buildTileScene, type TileScene } from "./scene";
+import { buildHalfPlaneScene, buildHyperbolicScene, type HyperbolicScene } from "./scene";
 import type { Viewport } from "./viewport";
 import { createWebGLRenderer, type WebGLInitResult } from "./webglRenderer";
 
@@ -59,7 +59,7 @@ export function createRenderEngine(
         const viewport = computeViewport(rect, canvas);
         const isHyperbolic = request.geometry === "hyperbolic";
         const scene = isHyperbolic
-            ? buildTileScene(request.params, viewport)
+            ? buildHyperbolicScene(request.params, viewport)
             : buildHalfPlaneScene(request.halfPlanes, viewport);
         const hasWebGLOutput = Boolean(webgl?.ready && webgl.canvas);
         const canvasStyle: CanvasTileStyle = {
@@ -105,7 +105,7 @@ export function createRenderEngine(
 
 function renderCanvasLayer(
     ctx: CanvasRenderingContext2D,
-    scene: TileScene,
+    scene: HyperbolicScene,
     style?: CanvasTileStyle,
 ) {
     renderTileLayer(ctx, scene, style);

--- a/src/render/engine.ts
+++ b/src/render/engine.ts
@@ -57,14 +57,18 @@ export function createRenderEngine(
         setCanvasDPR(canvas);
         const rect = canvas.getBoundingClientRect();
         const viewport = computeViewport(rect, canvas);
-        const scene =
-            request.geometry === "hyperbolic"
-                ? buildTileScene(request.params, viewport)
-                : buildHalfPlaneScene(request.halfPlanes, viewport);
+        const isHyperbolic = request.geometry === "hyperbolic";
+        const scene = isHyperbolic
+            ? buildTileScene(request.params, viewport)
+            : buildHalfPlaneScene(request.halfPlanes, viewport);
         const hasWebGLOutput = Boolean(webgl?.ready && webgl.canvas);
-        const canvasStyle = hasWebGLOutput ? { tileStroke: "rgba(0,0,0,0)" } : undefined;
+        const canvasStyle = isHyperbolic
+            ? hasWebGLOutput
+                ? { tileStroke: "rgba(0,0,0,0)" }
+                : undefined
+            : { drawDisk: false };
         renderCanvasLayer(ctx, scene, canvasStyle);
-        if (webgl) {
+        if (webgl && isHyperbolic) {
             if (hasWebGLOutput) {
                 syncWebGLCanvas(webgl, canvas);
                 webgl.renderer.render(scene, viewport);

--- a/src/render/engine.ts
+++ b/src/render/engine.ts
@@ -62,21 +62,23 @@ export function createRenderEngine(
             ? buildTileScene(request.params, viewport)
             : buildHalfPlaneScene(request.halfPlanes, viewport);
         const hasWebGLOutput = Boolean(webgl?.ready && webgl.canvas);
-        const canvasStyle = isHyperbolic
-            ? hasWebGLOutput
-                ? { tileStroke: "rgba(0,0,0,0)" }
-                : undefined
-            : { drawDisk: false };
+        const canvasStyle: CanvasTileStyle = {
+            drawDisk: isHyperbolic,
+        };
+        if (hasWebGLOutput) {
+            canvasStyle.tileStroke = "rgba(0,0,0,0)";
+        }
         renderCanvasLayer(ctx, scene, canvasStyle);
-        if (webgl && isHyperbolic) {
+        if (webgl) {
+            const clipToDisk = isHyperbolic;
             if (hasWebGLOutput) {
                 syncWebGLCanvas(webgl, canvas);
-                webgl.renderer.render(scene, viewport);
+                webgl.renderer.render(scene, viewport, { clipToDisk });
                 if (webgl.canvas) {
                     ctx.drawImage(webgl.canvas, 0, 0, canvas.width, canvas.height);
                 }
             } else {
-                webgl.renderer.render(scene, viewport);
+                webgl.renderer.render(scene, viewport, { clipToDisk });
             }
         }
     };

--- a/src/render/engine.ts
+++ b/src/render/engine.ts
@@ -68,7 +68,7 @@ export function createRenderEngine(
         if (hasWebGLOutput) {
             canvasStyle.tileStroke = "rgba(0,0,0,0)";
         }
-        renderCanvasLayer(ctx, scene, canvasStyle);
+        renderCanvasLayer(ctx, scene, viewport, canvasStyle);
         if (webgl) {
             const clipToDisk = scene.geometry === "hyperbolic";
             if (hasWebGLOutput) {
@@ -106,9 +106,10 @@ export function createRenderEngine(
 function renderCanvasLayer(
     ctx: CanvasRenderingContext2D,
     scene: RenderScene,
+    viewport: Viewport,
     style?: CanvasTileStyle,
 ) {
-    renderTileLayer(ctx, scene, style);
+    renderTileLayer(ctx, scene, viewport, style);
 }
 
 function computeViewport(rect: DOMRect, canvas: HTMLCanvasElement): Viewport {

--- a/src/render/primitives.ts
+++ b/src/render/primitives.ts
@@ -17,8 +17,46 @@ export function geodesicSpec(geo: Geodesic, vp: Viewport): CircleSpec | LineSpec
         const r = Math.abs(vp.scale || 1) * geo.r;
         return { cx: c.x, cy: c.y, r };
     }
-    // diameter through origin in direction dir (unit), draw as a line through screen center
-    const a = worldToScreen(vp, { x: -geo.dir.x, y: -geo.dir.y });
-    const b = worldToScreen(vp, { x: geo.dir.x, y: geo.dir.y });
+    if (geo.kind === "diameter") {
+        const a = worldToScreen(vp, { x: -geo.dir.x, y: -geo.dir.y });
+        const b = worldToScreen(vp, { x: geo.dir.x, y: geo.dir.y });
+        return { x1: a.x, y1: a.y, x2: b.x, y2: b.y };
+    }
+    // half-plane: draw intersection of line with unit disk
+    const normal = geo.normal;
+    const offset = geo.offset;
+    const t = normalize({ x: -normal.y, y: normal.x });
+    const closest = { x: -offset * normal.x, y: -offset * normal.y };
+    const intersections = intersectWithUnitDisk(closest, t);
+    const a = worldToScreen(vp, intersections[0]);
+    const b = worldToScreen(vp, intersections[1]);
     return { x1: a.x, y1: a.y, x2: b.x, y2: b.y };
+}
+
+function normalize(v: { x: number; y: number }): { x: number; y: number } {
+    const len = Math.hypot(v.x, v.y) || 1;
+    return { x: v.x / len, y: v.y / len };
+}
+
+function intersectWithUnitDisk(
+    base: { x: number; y: number },
+    dir: { x: number; y: number },
+): [{ x: number; y: number }, { x: number; y: number }] {
+    const dotBT = base.x * dir.x + base.y * dir.y;
+    const baseLenSq = base.x * base.x + base.y * base.y;
+    const disc = dotBT * dotBT - (baseLenSq - 1);
+    if (disc <= 0) {
+        const scale = 2;
+        return [
+            { x: base.x - scale * dir.x, y: base.y - scale * dir.y },
+            { x: base.x + scale * dir.x, y: base.y + scale * dir.y },
+        ];
+    }
+    const root = Math.sqrt(disc);
+    const lambda1 = -dotBT - root;
+    const lambda2 = -dotBT + root;
+    return [
+        { x: base.x + lambda1 * dir.x, y: base.y + lambda1 * dir.y },
+        { x: base.x + lambda2 * dir.x, y: base.y + lambda2 * dir.y },
+    ];
 }

--- a/src/render/scene.ts
+++ b/src/render/scene.ts
@@ -21,9 +21,17 @@ export type GeodesicPrimitive =
     | (GeodesicPrimitiveBase & { kind: "line"; line: LineSpec });
 
 export type HyperbolicScene = {
+    geometry: "hyperbolic";
     disk: CircleSpec;
-    tiles: GeodesicPrimitive[];
+    geodesics: GeodesicPrimitive[];
 };
+
+export type EuclideanScene = {
+    geometry: "euclidean";
+    geodesics: GeodesicPrimitive[];
+};
+
+export type RenderScene = HyperbolicScene | EuclideanScene;
 
 function buildGeodesicPrimitives(faces: TriangleFace[], vp: Viewport): GeodesicPrimitive[] {
     const edges = facesToEdgeGeodesics(faces);
@@ -46,14 +54,14 @@ function buildGeodesicPrimitives(faces: TriangleFace[], vp: Viewport): GeodesicP
 export function buildHyperbolicScene(params: TilingParams, vp: Viewport): HyperbolicScene {
     const { faces } = buildTiling(params);
     return {
+        geometry: "hyperbolic",
         disk: unitDiskSpec(vp),
-        tiles: buildGeodesicPrimitives(faces, vp),
+        geodesics: buildGeodesicPrimitives(faces, vp),
     };
 }
 
-export function buildHalfPlaneScene(planes: HalfPlane[], vp: Viewport): HyperbolicScene {
-    const disk = unitDiskSpec(vp);
-    const tiles: GeodesicPrimitive[] = planes.map((plane, index) => {
+export function buildEuclideanScene(planes: HalfPlane[], vp: Viewport): EuclideanScene {
+    const geodesics: GeodesicPrimitive[] = planes.map((plane, index) => {
         const geodesic = toGeodesicHalfPlane(plane);
         const spec = geodesicSpec(geodesic, vp);
         const base: GeodesicPrimitiveBase = {
@@ -68,5 +76,5 @@ export function buildHalfPlaneScene(planes: HalfPlane[], vp: Viewport): Hyperbol
         }
         return { ...base, kind: "line", line: spec };
     });
-    return { disk, tiles };
+    return { geometry: "euclidean", geodesics };
 }

--- a/src/render/scene.ts
+++ b/src/render/scene.ts
@@ -1,4 +1,6 @@
 import type { Geodesic } from "../geom/geodesic";
+import type { HalfPlane } from "../geom/halfPlane";
+import { toGeodesicHalfPlane } from "../geom/halfPlane";
 import type { TilingParams } from "../geom/tiling";
 import { buildTiling } from "../geom/tiling";
 import type { TriangleFace } from "../geom/triangle-group";
@@ -47,4 +49,24 @@ export function buildTileScene(params: TilingParams, vp: Viewport): TileScene {
         disk: unitDiskSpec(vp),
         tiles: buildTilePrimitives(faces, vp),
     };
+}
+
+export function buildHalfPlaneScene(planes: HalfPlane[], vp: Viewport): TileScene {
+    const disk = unitDiskSpec(vp);
+    const tiles: TilePrimitive[] = planes.map((plane, index) => {
+        const geodesic = toGeodesicHalfPlane(plane);
+        const spec = geodesicSpec(geodesic, vp);
+        const base: TilePrimitiveBase = {
+            id: `plane-${index}`,
+            faceId: `plane-${index}`,
+            faceWord: "plane",
+            edgeIndex: 0,
+            geodesic,
+        };
+        if ("r" in spec) {
+            return { ...base, kind: "circle", circle: spec };
+        }
+        return { ...base, kind: "line", line: spec };
+    });
+    return { disk, tiles };
 }

--- a/src/render/scene.ts
+++ b/src/render/scene.ts
@@ -1,6 +1,6 @@
 import type { Geodesic } from "../geom/geodesic";
 import type { HalfPlane } from "../geom/halfPlane";
-import { toGeodesicHalfPlane } from "../geom/halfPlane";
+import { normalizeHalfPlane } from "../geom/halfPlane";
 import type { TilingParams } from "../geom/tiling";
 import { buildTiling } from "../geom/tiling";
 import type { TriangleFace } from "../geom/triangle-group";
@@ -28,7 +28,7 @@ export type HyperbolicScene = {
 
 export type EuclideanScene = {
     geometry: "euclidean";
-    geodesics: GeodesicPrimitive[];
+    halfPlanes: HalfPlane[];
 };
 
 export type RenderScene = HyperbolicScene | EuclideanScene;
@@ -60,21 +60,6 @@ export function buildHyperbolicScene(params: TilingParams, vp: Viewport): Hyperb
     };
 }
 
-export function buildEuclideanScene(planes: HalfPlane[], vp: Viewport): EuclideanScene {
-    const geodesics: GeodesicPrimitive[] = planes.map((plane, index) => {
-        const geodesic = toGeodesicHalfPlane(plane);
-        const spec = geodesicSpec(geodesic, vp);
-        const base: GeodesicPrimitiveBase = {
-            id: `plane-${index}`,
-            faceId: `plane-${index}`,
-            faceWord: "plane",
-            edgeIndex: 0,
-            geodesic,
-        };
-        if ("r" in spec) {
-            return { ...base, kind: "circle", circle: spec };
-        }
-        return { ...base, kind: "line", line: spec };
-    });
-    return { geometry: "euclidean", geodesics };
+export function buildEuclideanScene(planes: HalfPlane[], _vp: Viewport): EuclideanScene {
+    return { geometry: "euclidean", halfPlanes: planes.map((plane) => normalizeHalfPlane(plane)) };
 }

--- a/src/render/scene.ts
+++ b/src/render/scene.ts
@@ -8,7 +8,7 @@ import { type CircleSpec, geodesicSpec, type LineSpec, unitDiskSpec } from "./pr
 import { facesToEdgeGeodesics } from "./tilingAdapter";
 import type { Viewport } from "./viewport";
 
-export type TilePrimitiveBase = {
+export type GeodesicPrimitiveBase = {
     id: string;
     faceId: string;
     faceWord: string;
@@ -16,20 +16,20 @@ export type TilePrimitiveBase = {
     geodesic: Geodesic;
 };
 
-export type TilePrimitive =
-    | (TilePrimitiveBase & { kind: "circle"; circle: CircleSpec })
-    | (TilePrimitiveBase & { kind: "line"; line: LineSpec });
+export type GeodesicPrimitive =
+    | (GeodesicPrimitiveBase & { kind: "circle"; circle: CircleSpec })
+    | (GeodesicPrimitiveBase & { kind: "line"; line: LineSpec });
 
-export type TileScene = {
+export type HyperbolicScene = {
     disk: CircleSpec;
-    tiles: TilePrimitive[];
+    tiles: GeodesicPrimitive[];
 };
 
-function buildTilePrimitives(faces: TriangleFace[], vp: Viewport): TilePrimitive[] {
+function buildGeodesicPrimitives(faces: TriangleFace[], vp: Viewport): GeodesicPrimitive[] {
     const edges = facesToEdgeGeodesics(faces);
     return edges.map((edge) => {
         const spec = geodesicSpec(edge.geodesic, vp);
-        const base: TilePrimitiveBase = {
+        const base: GeodesicPrimitiveBase = {
             id: `${edge.faceId}:${edge.edgeIndex}`,
             faceId: edge.faceId,
             faceWord: edge.faceWord,
@@ -37,26 +37,26 @@ function buildTilePrimitives(faces: TriangleFace[], vp: Viewport): TilePrimitive
             geodesic: edge.geodesic,
         };
         if ("r" in spec) {
-            return { ...base, kind: "circle", circle: spec } as TilePrimitive;
+            return { ...base, kind: "circle", circle: spec } as GeodesicPrimitive;
         }
-        return { ...base, kind: "line", line: spec } as TilePrimitive;
+        return { ...base, kind: "line", line: spec } as GeodesicPrimitive;
     });
 }
 
-export function buildTileScene(params: TilingParams, vp: Viewport): TileScene {
+export function buildHyperbolicScene(params: TilingParams, vp: Viewport): HyperbolicScene {
     const { faces } = buildTiling(params);
     return {
         disk: unitDiskSpec(vp),
-        tiles: buildTilePrimitives(faces, vp),
+        tiles: buildGeodesicPrimitives(faces, vp),
     };
 }
 
-export function buildHalfPlaneScene(planes: HalfPlane[], vp: Viewport): TileScene {
+export function buildHalfPlaneScene(planes: HalfPlane[], vp: Viewport): HyperbolicScene {
     const disk = unitDiskSpec(vp);
-    const tiles: TilePrimitive[] = planes.map((plane, index) => {
+    const tiles: GeodesicPrimitive[] = planes.map((plane, index) => {
         const geodesic = toGeodesicHalfPlane(plane);
         const spec = geodesicSpec(geodesic, vp);
-        const base: TilePrimitiveBase = {
+        const base: GeodesicPrimitiveBase = {
             id: `plane-${index}`,
             faceId: `plane-${index}`,
             faceWord: "plane",

--- a/src/render/webgl/geodesicUniforms.ts
+++ b/src/render/webgl/geodesicUniforms.ts
@@ -1,5 +1,5 @@
 import type { Geodesic } from "../../geom/geodesic";
-import type { HyperbolicScene } from "../scene";
+import type { RenderScene } from "../scene";
 
 export const MAX_UNIFORM_GEODESICS = 256;
 const COMPONENTS_PER_VEC4 = 4;
@@ -18,13 +18,13 @@ export function createGeodesicUniformBuffers(
 }
 
 export function packSceneGeodesics(
-    scene: HyperbolicScene,
+    scene: RenderScene,
     buffers: GeodesicUniformBuffers,
     limit: number = MAX_UNIFORM_GEODESICS,
 ): number {
     const maxCount = Math.min(limit, buffers.data.length / COMPONENTS_PER_VEC4);
     let count = 0;
-    for (const primitive of scene.tiles) {
+    for (const primitive of scene.geodesics) {
         if (count >= maxCount) break;
         if (primitive.geodesic.kind === "circle") {
             packCircleGeodesic(primitive.geodesic, buffers, count);

--- a/src/render/webgl/geodesicUniforms.ts
+++ b/src/render/webgl/geodesicUniforms.ts
@@ -1,5 +1,5 @@
 import type { Geodesic } from "../../geom/geodesic";
-import type { TileScene } from "../scene";
+import type { HyperbolicScene } from "../scene";
 
 export const MAX_UNIFORM_GEODESICS = 256;
 const COMPONENTS_PER_VEC4 = 4;
@@ -18,7 +18,7 @@ export function createGeodesicUniformBuffers(
 }
 
 export function packSceneGeodesics(
-    scene: TileScene,
+    scene: HyperbolicScene,
     buffers: GeodesicUniformBuffers,
     limit: number = MAX_UNIFORM_GEODESICS,
 ): number {

--- a/src/render/webgl/shaders/geodesic.frag
+++ b/src/render/webgl/shaders/geodesic.frag
@@ -8,6 +8,7 @@ uniform int uGeodesicCount;
 uniform float uLineWidth;
 uniform float uFeather;
 uniform vec3 uLineColor;
+uniform int uClipToDisk;
 uniform vec3 uViewport; // (scale, tx, ty)
 
 const int MAX_GEODESICS = __MAX_GEODESICS__;
@@ -35,10 +36,13 @@ float sdfLineWorld(vec2 worldPoint, vec2 normal, float offset) {
 
 void main() {
     vec2 worldPoint = screenToWorld(vFragCoord);
-    float diskDistPx = (length(worldPoint) - 1.0) * uViewport.x;
-    float diskMask = 1.0 - smoothstep(0.0, uFeather, diskDistPx);
-    if (diskMask <= 0.0) {
-        discard;
+    float diskMask = 1.0;
+    if (uClipToDisk == 1) {
+        float diskDistPx = (length(worldPoint) - 1.0) * uViewport.x;
+        diskMask = 1.0 - smoothstep(0.0, uFeather, diskDistPx);
+        if (diskMask <= 0.0) {
+            discard;
+        }
     }
 
     float minSdfWorld = 1e9;

--- a/src/render/webgl/shaders/geodesic.frag
+++ b/src/render/webgl/shaders/geodesic.frag
@@ -29,9 +29,8 @@ float sdfCircleWorld(vec2 worldPoint, vec4 params) {
     return numerator / max(denom, 1e-6);
 }
 
-float sdfDiameterWorld(vec2 worldPoint, vec2 dir) {
-    vec2 normal = vec2(-dir.y, dir.x);
-    return abs(dot(worldPoint, normal));
+float sdfLineWorld(vec2 worldPoint, vec2 normal, float offset) {
+    return abs(dot(worldPoint, normal) + offset);
 }
 
 void main() {
@@ -51,8 +50,8 @@ void main() {
         if (packed.w < 0.5) {
             minSdfWorld = min(minSdfWorld, sdfCircleWorld(worldPoint, packed));
         } else {
-            vec2 dir = normalize(packed.xy);
-            minSdfWorld = min(minSdfWorld, sdfDiameterWorld(worldPoint, dir));
+            vec2 normal = normalize(packed.xy);
+            minSdfWorld = min(minSdfWorld, sdfLineWorld(worldPoint, normal, packed.z));
         }
     }
 

--- a/src/render/webglRenderer.ts
+++ b/src/render/webglRenderer.ts
@@ -1,4 +1,4 @@
-import type { HyperbolicScene } from "./scene";
+import type { RenderScene } from "./scene";
 import type { Viewport } from "./viewport";
 import {
     createGeodesicUniformBuffers,
@@ -13,7 +13,7 @@ const LINE_FEATHER = 0.9;
 const LINE_COLOR = [74 / 255, 144 / 255, 226 / 255] as const;
 
 export interface WebGLRenderer {
-    render(scene: HyperbolicScene, viewport: Viewport, options?: { clipToDisk?: boolean }): void;
+    render(scene: RenderScene, viewport: Viewport, options?: { clipToDisk?: boolean }): void;
     dispose(): void;
 }
 
@@ -53,7 +53,7 @@ function createStubRenderer(canvas: HTMLCanvasElement | null): WebGLInitResult {
         canvas,
         ready: false,
         renderer: {
-            render: (_scene: HyperbolicScene, _viewport: Viewport) => {
+            render: (_scene: RenderScene, _viewport: Viewport) => {
                 /* no-op */
             },
             dispose: () => {
@@ -112,7 +112,7 @@ function createRealRenderer(
         ready: true,
         renderer: {
             render: (
-                scene: HyperbolicScene,
+                scene: RenderScene,
                 viewport: Viewport,
                 options?: { clipToDisk?: boolean },
             ) => {

--- a/src/render/webglRenderer.ts
+++ b/src/render/webglRenderer.ts
@@ -13,7 +13,7 @@ const LINE_FEATHER = 0.9;
 const LINE_COLOR = [74 / 255, 144 / 255, 226 / 255] as const;
 
 export interface WebGLRenderer {
-    render(scene: TileScene, viewport: Viewport): void;
+    render(scene: TileScene, viewport: Viewport, options?: { clipToDisk?: boolean }): void;
     dispose(): void;
 }
 
@@ -111,13 +111,15 @@ function createRealRenderer(
         canvas,
         ready: true,
         renderer: {
-            render: (scene: TileScene, viewport: Viewport) => {
+            render: (scene: TileScene, viewport: Viewport, options?: { clipToDisk?: boolean }) => {
+                const clipToDisk = options?.clipToDisk !== false;
                 const width = canvas.width || gl.drawingBufferWidth || 1;
                 const height = canvas.height || gl.drawingBufferHeight || 1;
                 gl.viewport(0, 0, width, height);
                 gl.useProgram(program);
                 gl.uniform2f(uniforms.resolution, width, height);
                 gl.uniform3f(uniforms.viewport, viewport.scale, viewport.tx, viewport.ty);
+                gl.uniform1i(uniforms.clipToDisk, clipToDisk ? 1 : 0);
                 const count = packSceneGeodesics(scene, geodesicBuffers, MAX_UNIFORM_GEODESICS);
                 gl.uniform1i(uniforms.geodesicCount, count);
                 gl.uniform4fv(uniforms.geodesics, geodesicBuffers.data);
@@ -183,6 +185,7 @@ type UniformLocations = {
     viewport: WebGLUniformLocation;
     geodesicCount: WebGLUniformLocation;
     geodesics: WebGLUniformLocation;
+    clipToDisk: WebGLUniformLocation;
 };
 
 function resolveUniformLocations(
@@ -193,7 +196,8 @@ function resolveUniformLocations(
     const viewport = getUniformLocation(gl, program, "uViewport");
     const geodesicCount = getUniformLocation(gl, program, "uGeodesicCount");
     const geodesics = getUniformLocation(gl, program, "uGeodesicsA[0]");
-    return { resolution, viewport, geodesicCount, geodesics };
+    const clipToDisk = getUniformLocation(gl, program, "uClipToDisk");
+    return { resolution, viewport, geodesicCount, geodesics, clipToDisk };
 }
 
 function getUniformLocation(

--- a/src/render/webglRenderer.ts
+++ b/src/render/webglRenderer.ts
@@ -1,4 +1,4 @@
-import type { TileScene } from "./scene";
+import type { HyperbolicScene } from "./scene";
 import type { Viewport } from "./viewport";
 import {
     createGeodesicUniformBuffers,
@@ -13,7 +13,7 @@ const LINE_FEATHER = 0.9;
 const LINE_COLOR = [74 / 255, 144 / 255, 226 / 255] as const;
 
 export interface WebGLRenderer {
-    render(scene: TileScene, viewport: Viewport, options?: { clipToDisk?: boolean }): void;
+    render(scene: HyperbolicScene, viewport: Viewport, options?: { clipToDisk?: boolean }): void;
     dispose(): void;
 }
 
@@ -53,7 +53,7 @@ function createStubRenderer(canvas: HTMLCanvasElement | null): WebGLInitResult {
         canvas,
         ready: false,
         renderer: {
-            render: (_scene: TileScene, _viewport: Viewport) => {
+            render: (_scene: HyperbolicScene, _viewport: Viewport) => {
                 /* no-op */
             },
             dispose: () => {
@@ -111,7 +111,11 @@ function createRealRenderer(
         canvas,
         ready: true,
         renderer: {
-            render: (scene: TileScene, viewport: Viewport, options?: { clipToDisk?: boolean }) => {
+            render: (
+                scene: HyperbolicScene,
+                viewport: Viewport,
+                options?: { clipToDisk?: boolean },
+            ) => {
                 const clipToDisk = options?.clipToDisk !== false;
                 const width = canvas.width || gl.drawingBufferWidth || 1;
                 const height = canvas.height || gl.drawingBufferHeight || 1;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { buildEuclideanTriangle } from "../geom/euclideanTriangle";
+import type { HalfPlane } from "../geom/halfPlane";
 import { createRenderEngine, detectRenderMode, type RenderEngine } from "../render/engine";
 import { DepthControls } from "./components/DepthControls";
 import { ModeControls } from "./components/ModeControls";
@@ -7,17 +8,17 @@ import { PresetSelector } from "./components/PresetSelector";
 import { SnapControls } from "./components/SnapControls";
 import { StageCanvas } from "./components/StageCanvas";
 import { TriangleParamForm } from "./components/TriangleParamForm";
-import type { TrianglePreset } from "./hooks/useTriangleParams";
 import { useTriangleParams } from "./hooks/useTriangleParams";
+import { getPresetsForGeometry, type TrianglePreset } from "./trianglePresets";
 
 const TRIANGLE_N_MAX = 100;
 const INITIAL_PARAMS = { p: 2, q: 3, r: 7, depth: 2 } as const;
 const DEPTH_RANGE = { min: 0, max: 10 } as const;
 
-const PQR_PRESETS: TrianglePreset[] = [
-    { label: "(3,3,3)", p: 3, q: 3, r: 3 },
-    { label: "(2,4,4)", p: 2, q: 4, r: 4 },
-    { label: "(2,3,6)", p: 2, q: 3, r: 6 },
+const DEFAULT_EUCLIDEAN_PLANES: HalfPlane[] = [
+    { normal: { x: 1, y: 0 }, offset: 0 },
+    { normal: { x: 0, y: 1 }, offset: 0 },
+    { normal: { x: -Math.SQRT1_2, y: Math.SQRT1_2 }, offset: 0 },
 ];
 
 export function App(): JSX.Element {
@@ -50,6 +51,11 @@ export function App(): JSX.Element {
         depthRange: DEPTH_RANGE,
     });
 
+    const presets = useMemo<readonly TrianglePreset[]>(
+        () => getPresetsForGeometry(geometryMode),
+        [geometryMode],
+    );
+
     useEffect(() => {
         const canvas = canvasRef.current;
         if (!canvas) return;
@@ -61,7 +67,7 @@ export function App(): JSX.Element {
         };
     }, [renderMode]);
 
-    const euclideanMirrors = useMemo(() => {
+    const euclideanHalfPlanes = useMemo(() => {
         if (geometryMode !== "euclidean" || paramError) {
             return null;
         }
@@ -78,13 +84,12 @@ export function App(): JSX.Element {
             renderEngineRef.current?.render({ geometry: "hyperbolic", params });
             return;
         }
-        if (euclideanMirrors) {
-            renderEngineRef.current?.render({
-                geometry: "euclidean",
-                halfPlanes: euclideanMirrors,
-            });
-        }
-    }, [geometryMode, params, euclideanMirrors]);
+        const halfPlanes = euclideanHalfPlanes ?? DEFAULT_EUCLIDEAN_PLANES;
+        renderEngineRef.current?.render({
+            geometry: "euclidean",
+            halfPlanes,
+        });
+    }, [geometryMode, params, euclideanHalfPlanes]);
 
     return (
         <div
@@ -101,7 +106,7 @@ export function App(): JSX.Element {
             <div style={{ display: "grid", gap: "12px", alignContent: "start" }}>
                 <h2 style={{ margin: 0, fontSize: "1.1rem" }}>Triangle Parameters</h2>
                 <PresetSelector
-                    presets={PQR_PRESETS}
+                    presets={presets}
                     anchor={anchor}
                     onSelect={setFromPreset}
                     onClear={clearAnchor}

--- a/src/ui/components/ModeControls.tsx
+++ b/src/ui/components/ModeControls.tsx
@@ -1,0 +1,47 @@
+import type { GeometryMode } from "../hooks/useTriangleParams";
+
+export type ModeControlsProps = {
+    geometryMode: GeometryMode;
+    onGeometryChange: (mode: GeometryMode) => void;
+    renderBackend: string;
+};
+
+const MODES: GeometryMode[] = ["hyperbolic", "euclidean"];
+
+const LABELS: Record<GeometryMode, string> = {
+    hyperbolic: "Hyperbolic",
+    euclidean: "Euclidean",
+};
+
+export function ModeControls({ geometryMode, onGeometryChange, renderBackend }: ModeControlsProps) {
+    return (
+        <div style={{ display: "grid", gap: "8px" }}>
+            <div style={{ display: "grid", gap: "4px" }}>
+                <span style={{ fontWeight: 600 }}>Geometry Mode</span>
+                <div style={{ display: "flex", flexWrap: "wrap", gap: "8px" }}>
+                    {MODES.map((mode) => {
+                        const active = mode === geometryMode;
+                        return (
+                            <button
+                                key={mode}
+                                type="button"
+                                onClick={() => onGeometryChange(mode)}
+                                style={{
+                                    padding: "4px 8px",
+                                    border: active ? "1px solid #4a90e2" : "1px solid #bbb",
+                                    backgroundColor: active ? "#e6f1fc" : "#fff",
+                                    cursor: "pointer",
+                                }}
+                            >
+                                {LABELS[mode]}
+                            </button>
+                        );
+                    })}
+                </div>
+            </div>
+            <span style={{ fontSize: "0.8rem", color: "#555" }}>
+                Render backend: {renderBackend}
+            </span>
+        </div>
+    );
+}

--- a/src/ui/components/PresetSelector.tsx
+++ b/src/ui/components/PresetSelector.tsx
@@ -1,7 +1,7 @@
-import type { TrianglePreset } from "../hooks/useTriangleParams";
+import type { TrianglePreset } from "../trianglePresets";
 
 export type PresetSelectorProps = {
-    presets: TrianglePreset[];
+    presets: readonly TrianglePreset[];
     anchor: { p: number; q: number } | null;
     onSelect: (preset: TrianglePreset) => void;
     onClear: () => void;

--- a/src/ui/components/SnapControls.tsx
+++ b/src/ui/components/SnapControls.tsx
@@ -1,14 +1,9 @@
 export type SnapControlsProps = {
     snapEnabled: boolean;
-    renderMode: string;
     onToggle: (enabled: boolean) => void;
 };
 
-export function SnapControls({
-    snapEnabled,
-    renderMode,
-    onToggle,
-}: SnapControlsProps): JSX.Element {
+export function SnapControls({ snapEnabled, onToggle }: SnapControlsProps): JSX.Element {
     return (
         <div style={{ display: "grid", gap: "8px" }}>
             <label style={{ display: "flex", alignItems: "center", gap: "8px" }}>
@@ -19,7 +14,6 @@ export function SnapControls({
                     onChange={(event) => onToggle(event.target.checked)}
                 />
             </label>
-            <span style={{ fontSize: "0.8rem", color: "#555" }}>Render mode: {renderMode}</span>
         </div>
     );
 }

--- a/src/ui/components/TriangleParamForm.tsx
+++ b/src/ui/components/TriangleParamForm.tsx
@@ -1,17 +1,20 @@
 import type { ChangeEvent } from "react";
 import type { TilingParams } from "../../geom/tiling";
 import type { PqrKey } from "../../geom/triangleSnap";
+import type { GeometryMode } from "../hooks/useTriangleParams";
 
 export type TriangleParamFormProps = {
     formInputs: Record<PqrKey, string>;
     params: TilingParams;
     anchor: { p: number; q: number } | null;
     paramError: string | null;
+    paramWarning?: string | null;
     rRange: { min: number; max: number };
     rStep: number;
     rSliderValue: number;
     onParamChange: (key: PqrKey, value: string) => void;
     onRSliderChange: (value: number) => void;
+    geometryMode: GeometryMode;
 };
 
 export function TriangleParamForm({
@@ -19,11 +22,13 @@ export function TriangleParamForm({
     params,
     anchor,
     paramError,
+    paramWarning,
     rRange,
     rStep,
     rSliderValue,
     onParamChange,
     onRSliderChange,
+    geometryMode,
 }: TriangleParamFormProps): JSX.Element {
     const handleParamChange = (key: PqrKey) => (event: ChangeEvent<HTMLInputElement>) => {
         onParamChange(key, event.target.value);
@@ -65,8 +70,14 @@ export function TriangleParamForm({
                 </span>
             </label>
             <p style={{ margin: 0, color: paramError ? "#c0392b" : "#555" }}>
-                {paramError ?? "Constraint: 1/p + 1/q + 1/r < 1"}
+                {paramError ??
+                    (geometryMode === "euclidean"
+                        ? "Constraint: 1/p + 1/q + 1/r = 1"
+                        : "Constraint: 1/p + 1/q + 1/r < 1")}
             </p>
+            {paramWarning ? (
+                <p style={{ margin: 0, fontSize: "0.8rem", color: "#a67c00" }}>{paramWarning}</p>
+            ) : null}
             <p style={{ margin: 0, fontSize: "0.85rem", color: "#555" }}>
                 Current: ({params.p}, {params.q}, {params.r})
             </p>

--- a/src/ui/trianglePresets.ts
+++ b/src/ui/trianglePresets.ts
@@ -1,0 +1,32 @@
+export type GeometryMode = "hyperbolic" | "euclidean";
+
+export type TrianglePreset = {
+    label: string;
+    p: number;
+    q: number;
+    r: number;
+};
+
+const HYPERBOLIC_PRESETS: TrianglePreset[] = [
+    { label: "(2,3,7)", p: 2, q: 3, r: 7 },
+    { label: "(2,4,5)", p: 2, q: 4, r: 5 },
+    { label: "(3,3,4)", p: 3, q: 3, r: 4 },
+];
+
+const EUCLIDEAN_PRESETS: TrianglePreset[] = [
+    { label: "(3,3,3)", p: 3, q: 3, r: 3 },
+    { label: "(2,4,4)", p: 2, q: 4, r: 4 },
+    { label: "(2,3,6)", p: 2, q: 3, r: 6 },
+];
+
+const PRESETS_BY_MODE: Record<GeometryMode, TrianglePreset[]> = {
+    hyperbolic: HYPERBOLIC_PRESETS,
+    euclidean: EUCLIDEAN_PRESETS,
+};
+
+export const DEFAULT_HYPERBOLIC_PRESET = HYPERBOLIC_PRESETS[0];
+export const DEFAULT_EUCLIDEAN_PRESET = EUCLIDEAN_PRESETS[0];
+
+export function getPresetsForGeometry(mode: GeometryMode): readonly TrianglePreset[] {
+    return PRESETS_BY_MODE[mode];
+}

--- a/tests/property/euclideanReflection.properties.test.ts
+++ b/tests/property/euclideanReflection.properties.test.ts
@@ -1,0 +1,67 @@
+import { fc, test } from "@fast-check/vitest";
+import { reflectAcrossHalfPlane } from "../../src/geom/halfPlane";
+
+const normalArb = fc
+    .record({
+        x: fc.double({ min: -1, max: 1, noNaN: true, noDefaultInfinity: true }),
+        y: fc.double({ min: -1, max: 1, noNaN: true, noDefaultInfinity: true }),
+    })
+    .filter((n) => Math.hypot(n.x, n.y) > 1e-6);
+
+const offsetArb = fc.double({ min: -2, max: 2, noNaN: true, noDefaultInfinity: true });
+
+const pointArb = fc.record({
+    x: fc.double({ min: -5, max: 5, noNaN: true, noDefaultInfinity: true }),
+    y: fc.double({ min: -5, max: 5, noNaN: true, noDefaultInfinity: true }),
+});
+
+function planeEval(
+    normal: { x: number; y: number },
+    offset: number,
+    point: { x: number; y: number },
+): number {
+    return normal.x * point.x + normal.y * point.y + offset;
+}
+
+function normalize(n: { x: number; y: number }): { x: number; y: number } {
+    const len = Math.hypot(n.x, n.y) || 1;
+    return { x: n.x / len, y: n.y / len };
+}
+
+test.prop([normalArb, offsetArb, pointArb])(
+    "reflection across a half-plane is an involution",
+    (n, offset, point) => {
+        const plane = { normal: normalize(n), offset };
+        const reflect = reflectAcrossHalfPlane(plane);
+        const once = reflect(point);
+        const twice = reflect(once);
+        expect(twice.x).toBeCloseTo(point.x, 12);
+        expect(twice.y).toBeCloseTo(point.y, 12);
+    },
+);
+
+test.prop([normalArb, offsetArb, pointArb])(
+    "reflection preserves absolute distance to the boundary line",
+    (n, offset, point) => {
+        const plane = { normal: normalize(n), offset };
+        const reflect = reflectAcrossHalfPlane(plane);
+        const valueBefore = planeEval(plane.normal, plane.offset, point);
+        const reflected = reflect(point);
+        const valueAfter = planeEval(plane.normal, plane.offset, reflected);
+        expect(Math.abs(valueAfter)).toBeCloseTo(Math.abs(valueBefore), 12);
+    },
+);
+
+test.prop([normalArb, offsetArb, pointArb])(
+    "flipping the normal sign does not change the reflection",
+    (n, offset, point) => {
+        const plane = { normal: normalize(n), offset };
+        const flipped = { normal: { x: -plane.normal.x, y: -plane.normal.y }, offset: -offset };
+        const reflectA = reflectAcrossHalfPlane(plane);
+        const reflectB = reflectAcrossHalfPlane(flipped);
+        const ra = reflectA(point);
+        const rb = reflectB(point);
+        expect(ra.x).toBeCloseTo(rb.x, 12);
+        expect(ra.y).toBeCloseTo(rb.y, 12);
+    },
+);

--- a/tests/unit/geom/euclideanTriangle.test.ts
+++ b/tests/unit/geom/euclideanTriangle.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { buildEuclideanTriangle } from "../../../src/geom/euclideanTriangle";
+
+function planeEval(
+    normal: { x: number; y: number },
+    offset: number,
+    point: { x: number; y: number },
+): number {
+    return normal.x * point.x + normal.y * point.y + offset;
+}
+
+function length(v: { x: number; y: number }): number {
+    return Math.hypot(v.x, v.y);
+}
+
+function barycenter(
+    verts: [{ x: number; y: number }, { x: number; y: number }, { x: number; y: number }],
+) {
+    return {
+        x: (verts[0].x + verts[1].x + verts[2].x) / 3,
+        y: (verts[0].y + verts[1].y + verts[2].y) / 3,
+    };
+}
+
+describe("buildEuclideanTriangle", () => {
+    it("returns unit-norm mirrors whose boundaries pass through the expected vertices", () => {
+        const tri = buildEuclideanTriangle(2, 4, 4);
+        const { mirrors, vertices } = tri;
+        const edges: Array<[{ x: number; y: number }, { x: number; y: number }]> = [
+            [vertices[1], vertices[2]],
+            [vertices[0], vertices[2]],
+            [vertices[0], vertices[1]],
+        ];
+        mirrors.forEach((plane, index) => {
+            expect(length(plane.normal)).toBeCloseTo(1, 12);
+            const [a, b] = edges[index];
+            expect(planeEval(plane.normal, plane.offset, a)).toBeCloseTo(0, 9);
+            expect(planeEval(plane.normal, plane.offset, b)).toBeCloseTo(0, 9);
+        });
+    });
+
+    it("places the triangle interior on the negative side of every mirror", () => {
+        const tri = buildEuclideanTriangle(3, 3, 3);
+        const center = barycenter(tri.vertices);
+        for (const plane of tri.mirrors) {
+            const value = planeEval(plane.normal, plane.offset, center);
+            expect(value).toBeLessThan(0);
+        }
+    });
+
+    it("produces angles that match the requested (p,q,r)", () => {
+        const tri = buildEuclideanTriangle(2, 3, 6);
+        const [alpha, beta, gamma] = tri.angles;
+        expect(alpha).toBeCloseTo(Math.PI / 2, 9);
+        expect(beta).toBeCloseTo(Math.PI / 3, 9);
+        expect(gamma).toBeCloseTo(Math.PI / 6, 9);
+    });
+});

--- a/tests/unit/geom/triangleParams.test.ts
+++ b/tests/unit/geom/triangleParams.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { normalizeDepth, validateTriangleParams } from "../../../src/geom/triangleParams";
+import {
+    normalizeDepth,
+    validateEuclideanParams,
+    validateTriangleParams,
+} from "../../../src/geom/triangleParams";
 
 describe("validateTriangleParams", () => {
     it("accepts hyperbolic triples", () => {
@@ -42,5 +46,31 @@ describe("normalizeDepth", () => {
 
     it("falls back to minimum for non-finite values", () => {
         expect(normalizeDepth(Number.NaN)).toBe(0);
+    });
+});
+
+describe("validateEuclideanParams", () => {
+    it("accepts canonical Euclidean triples", () => {
+        const result = validateEuclideanParams({ p: 3, q: 3, r: 3 });
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.warning).toBeUndefined();
+        }
+    });
+
+    it("emits warnings when close to the boundary", () => {
+        const result = validateEuclideanParams({ p: 3.0002, q: 3, r: 2.9996 });
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.warning).toBeDefined();
+        }
+    });
+
+    it("rejects non-euclidean triples", () => {
+        const result = validateEuclideanParams({ p: 2, q: 3, r: 7 });
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.errors).toContain("1/p + 1/q + 1/r must equal 1 (Euclidean regime)");
+        }
     });
 });

--- a/tests/unit/render/engine.test.ts
+++ b/tests/unit/render/engine.test.ts
@@ -43,7 +43,7 @@ describe("createRenderEngine", () => {
     it("renders via canvas mode", () => {
         const { canvas, ctx } = createMockCanvas();
         const engine = createRenderEngine(canvas, { mode: "canvas" });
-        engine.render({ p: 2, q: 3, r: 7, depth: 1 });
+        engine.render({ geometry: "hyperbolic", params: { p: 2, q: 3, r: 7, depth: 1 } });
         expect(ctx.clearRect).toHaveBeenCalled();
         engine.dispose();
     });
@@ -52,7 +52,7 @@ describe("createRenderEngine", () => {
         const { canvas, ctx } = createMockCanvas();
         const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
         const engine = createRenderEngine(canvas, { mode: "hybrid" });
-        engine.render({ p: 2, q: 3, r: 7, depth: 1 });
+        engine.render({ geometry: "hyperbolic", params: { p: 2, q: 3, r: 7, depth: 1 } });
         expect(errorSpy).toHaveBeenCalled();
         expect(ctx.drawImage).not.toHaveBeenCalled();
         expect(ctx.clearRect).toHaveBeenCalled();
@@ -65,10 +65,25 @@ describe("createRenderEngine", () => {
         const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
         const engine = createRenderEngine(canvas);
         expect(engine.getMode()).toBe("hybrid");
-        engine.render({ p: 2, q: 3, r: 7, depth: 1 });
+        engine.render({ geometry: "hyperbolic", params: { p: 2, q: 3, r: 7, depth: 1 } });
         expect(ctx.clearRect).toHaveBeenCalled();
         expect(ctx.drawImage).not.toHaveBeenCalled();
         engine.dispose();
         errorSpy.mockRestore();
+    });
+
+    it("accepts Euclidean render requests", () => {
+        const { canvas, ctx } = createMockCanvas();
+        const engine = createRenderEngine(canvas, { mode: "canvas" });
+        engine.render({
+            geometry: "euclidean",
+            halfPlanes: [
+                { normal: { x: 1, y: 0 }, offset: 0 },
+                { normal: { x: 0, y: 1 }, offset: 0 },
+                { normal: { x: -Math.sqrt(0.5), y: Math.sqrt(0.5) }, offset: 0 },
+            ],
+        });
+        expect(ctx.clearRect).toHaveBeenCalled();
+        engine.dispose();
     });
 });

--- a/tests/unit/render/scene.test.ts
+++ b/tests/unit/render/scene.test.ts
@@ -23,7 +23,7 @@ describe("buildEuclideanScene", () => {
     it("returns geodesic primitives without disk", () => {
         const scene = buildEuclideanScene(PLANES, VIEWPORT);
         expect(scene.geometry).toBe("euclidean");
-        expect(scene.geodesics.length).toBe(PLANES.length);
+        expect(scene.halfPlanes.length).toBe(PLANES.length);
         expect((scene as unknown as { disk?: unknown }).disk).toBeUndefined();
     });
 });

--- a/tests/unit/render/scene.test.ts
+++ b/tests/unit/render/scene.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { buildTileScene } from "../../../src/render/scene";
+import { buildHyperbolicScene } from "../../../src/render/scene";
 import type { Viewport } from "../../../src/render/viewport";
 
 const VIEWPORT: Viewport = { scale: 100, tx: 120, ty: 120 };
 
-describe("buildTileScene", () => {
+describe("buildHyperbolicScene", () => {
     it("returns disk and tile primitives", () => {
-        const scene = buildTileScene({ p: 2, q: 3, r: 7, depth: 1 }, VIEWPORT);
+        const scene = buildHyperbolicScene({ p: 2, q: 3, r: 7, depth: 1 }, VIEWPORT);
         expect(scene.disk.r).toBeGreaterThan(0);
         expect(scene.tiles.length).toBeGreaterThan(0);
         expect(scene.tiles[0]).toHaveProperty("kind");

--- a/tests/unit/render/scene.test.ts
+++ b/tests/unit/render/scene.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { buildHyperbolicScene } from "../../../src/render/scene";
+import type { HalfPlane } from "../../../src/geom/halfPlane";
+import { buildEuclideanScene, buildHyperbolicScene } from "../../../src/render/scene";
 import type { Viewport } from "../../../src/render/viewport";
 
 const VIEWPORT: Viewport = { scale: 100, tx: 120, ty: 120 };
+const PLANES: HalfPlane[] = [
+    { normal: { x: 1, y: 0 }, offset: 0 },
+    { normal: { x: 0, y: 1 }, offset: 0 },
+    { normal: { x: -Math.SQRT1_2, y: Math.SQRT1_2 }, offset: 0 },
+];
 
 describe("buildHyperbolicScene", () => {
     it("returns disk and tile primitives", () => {
@@ -10,5 +16,14 @@ describe("buildHyperbolicScene", () => {
         expect(scene.disk.r).toBeGreaterThan(0);
         expect(scene.geodesics.length).toBeGreaterThan(0);
         expect(scene.geodesics[0]).toHaveProperty("kind");
+    });
+});
+
+describe("buildEuclideanScene", () => {
+    it("returns geodesic primitives without disk", () => {
+        const scene = buildEuclideanScene(PLANES, VIEWPORT);
+        expect(scene.geometry).toBe("euclidean");
+        expect(scene.geodesics.length).toBe(PLANES.length);
+        expect((scene as unknown as { disk?: unknown }).disk).toBeUndefined();
     });
 });

--- a/tests/unit/render/scene.test.ts
+++ b/tests/unit/render/scene.test.ts
@@ -8,7 +8,7 @@ describe("buildHyperbolicScene", () => {
     it("returns disk and tile primitives", () => {
         const scene = buildHyperbolicScene({ p: 2, q: 3, r: 7, depth: 1 }, VIEWPORT);
         expect(scene.disk.r).toBeGreaterThan(0);
-        expect(scene.tiles.length).toBeGreaterThan(0);
-        expect(scene.tiles[0]).toHaveProperty("kind");
+        expect(scene.geodesics.length).toBeGreaterThan(0);
+        expect(scene.geodesics[0]).toHaveProperty("kind");
     });
 });

--- a/tests/unit/render/webgl/geodesicUniforms.test.ts
+++ b/tests/unit/render/webgl/geodesicUniforms.test.ts
@@ -38,9 +38,9 @@ describe("packSceneGeodesics", () => {
         // line entry
         const lineOffset = 4;
         const data = Array.from(buffers.data.slice(lineOffset, lineOffset + 4));
-        expect(data[0]).toBe(1);
-        expect(data[1]).toBe(0);
-        expect(data[2]).toBe(0);
+        expect(data[0]).toBeCloseTo(0, 12);
+        expect(data[1]).toBeCloseTo(1, 12);
+        expect(data[2]).toBeCloseTo(0, 12);
         expect(data[3]).toBe(1);
     });
 

--- a/tests/unit/render/webgl/geodesicUniforms.test.ts
+++ b/tests/unit/render/webgl/geodesicUniforms.test.ts
@@ -30,6 +30,14 @@ const SCENE: HyperbolicScene = {
     ],
 };
 
+const EUCLIDEAN_SCENE = {
+    geometry: "euclidean" as const,
+    halfPlanes: [
+        { normal: { x: 1, y: 0 }, offset: 0 },
+        { normal: { x: 0, y: 1 }, offset: 0 },
+    ],
+};
+
 describe("packSceneGeodesics", () => {
     it("packs circle and line primitives into uniform buffers", () => {
         const buffers = createGeodesicUniformBuffers(4);
@@ -62,5 +70,14 @@ describe("packSceneGeodesics", () => {
         const count = packSceneGeodesics(SCENE, buffers, 1);
         expect(count).toBe(1);
         expect(buffers.data.slice(4)).toEqual(new Float32Array([]));
+    });
+
+    it("packs euclidean half-planes as lines", () => {
+        const buffers = createGeodesicUniformBuffers(4);
+        const count = packSceneGeodesics(EUCLIDEAN_SCENE, buffers);
+        expect(count).toBe(EUCLIDEAN_SCENE.halfPlanes.length);
+        const data = Array.from(buffers.data.slice(0, 4));
+        expect(Math.hypot(data[0], data[1])).toBeCloseTo(1, 12);
+        expect(data[3]).toBe(1);
     });
 });

--- a/tests/unit/render/webgl/geodesicUniforms.test.ts
+++ b/tests/unit/render/webgl/geodesicUniforms.test.ts
@@ -6,8 +6,9 @@ import {
 } from "../../../../src/render/webgl/geodesicUniforms";
 
 const SCENE: HyperbolicScene = {
+    geometry: "hyperbolic",
     disk: { cx: 100, cy: 100, r: 90 },
-    tiles: [
+    geodesics: [
         {
             kind: "circle",
             id: "c:0",
@@ -47,7 +48,7 @@ describe("packSceneGeodesics", () => {
     it("clears the remainder of the buffers when there are fewer primitives than slots", () => {
         const buffers = createGeodesicUniformBuffers(4);
         buffers.data.fill(123);
-        const count = packSceneGeodesics({ ...SCENE, tiles: [SCENE.tiles[0]] }, buffers);
+        const count = packSceneGeodesics({ ...SCENE, geodesics: [SCENE.geodesics[0]] }, buffers);
         expect(count).toBe(1);
         expect(buffers.data[0]).toBe(0);
         expect(buffers.data[3]).toBe(0);

--- a/tests/unit/render/webgl/geodesicUniforms.test.ts
+++ b/tests/unit/render/webgl/geodesicUniforms.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import type { TileScene } from "../../../../src/render/scene";
+import type { HyperbolicScene } from "../../../../src/render/scene";
 import {
     createGeodesicUniformBuffers,
     packSceneGeodesics,
 } from "../../../../src/render/webgl/geodesicUniforms";
 
-const SCENE: TileScene = {
+const SCENE: HyperbolicScene = {
     disk: { cx: 100, cy: 100, r: 90 },
     tiles: [
         {

--- a/tests/unit/render/webglRenderer.test.ts
+++ b/tests/unit/render/webglRenderer.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import type { TileScene } from "../../../src/render/scene";
+import type { HyperbolicScene } from "../../../src/render/scene";
 import { createWebGLRenderer } from "../../../src/render/webglRenderer";
 
-const SCENE: TileScene = {
+const SCENE: HyperbolicScene = {
     disk: { cx: 0, cy: 0, r: 1 },
     tiles: [],
 };

--- a/tests/unit/render/webglRenderer.test.ts
+++ b/tests/unit/render/webglRenderer.test.ts
@@ -3,8 +3,9 @@ import type { HyperbolicScene } from "../../../src/render/scene";
 import { createWebGLRenderer } from "../../../src/render/webglRenderer";
 
 const SCENE: HyperbolicScene = {
+    geometry: "hyperbolic",
     disk: { cx: 0, cy: 0, r: 1 },
-    tiles: [],
+    geodesics: [],
 };
 
 describe("createWebGLRenderer", () => {

--- a/tests/unit/ui/components.test.tsx
+++ b/tests/unit/ui/components.test.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { describe, expect, it, vi } from "vitest";
 import type { PqrKey } from "../../../src/geom/triangleSnap";
 import { DepthControls } from "../../../src/ui/components/DepthControls";
+import { ModeControls } from "../../../src/ui/components/ModeControls";
 import { PresetSelector } from "../../../src/ui/components/PresetSelector";
 import { SnapControls } from "../../../src/ui/components/SnapControls";
 import { StageCanvas } from "../../../src/ui/components/StageCanvas";
@@ -55,7 +56,7 @@ describe("UI components", () => {
         const container = document.createElement("div");
         const root = createRoot(container);
         act(() => {
-            root.render(<SnapControls snapEnabled renderMode="webgl" onToggle={onToggle} />);
+            root.render(<SnapControls snapEnabled onToggle={onToggle} />);
         });
         const checkbox = container.querySelector("input[type=checkbox]") as HTMLInputElement;
         expect(checkbox).not.toBeNull();
@@ -63,6 +64,30 @@ describe("UI components", () => {
             checkbox.click();
         });
         expect(onToggle).toHaveBeenCalledWith(false);
+        act(() => {
+            root.unmount();
+        });
+    });
+
+    it("allows switching geometry modes", () => {
+        const onChange = vi.fn();
+        const container = document.createElement("div");
+        const root = createRoot(container);
+        act(() => {
+            root.render(
+                <ModeControls
+                    geometryMode="hyperbolic"
+                    onGeometryChange={onChange}
+                    renderBackend="hybrid"
+                />,
+            );
+        });
+        const buttons = Array.from(container.querySelectorAll("button"));
+        expect(buttons).toHaveLength(2);
+        act(() => {
+            buttons[1]?.click();
+        });
+        expect(onChange).toHaveBeenCalledWith("euclidean");
         act(() => {
             root.unmount();
         });
@@ -80,6 +105,8 @@ describe("UI components", () => {
                     params={{ p: 2, q: 3, r: 7, depth: 2 }}
                     anchor={null}
                     paramError={null}
+                    paramWarning="near boundary"
+                    geometryMode="hyperbolic"
                     rRange={{ min: 2, max: 10 }}
                     rStep={1}
                     rSliderValue={7}
@@ -103,6 +130,8 @@ describe("UI components", () => {
             slider.dispatchEvent(new Event("input", { bubbles: true }));
         });
         expect(onSlider).toHaveBeenCalledWith(8);
+        const warning = container.querySelector("p:nth-of-type(2)");
+        expect(warning?.textContent).toContain("near boundary");
 
         act(() => {
             root.unmount();

--- a/tests/unit/ui/presets.test.ts
+++ b/tests/unit/ui/presets.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { getPresetsForGeometry } from "../../../src/ui/trianglePresets";
+
+function reciprocalSum(p: number, q: number, r: number): number {
+    return 1 / p + 1 / q + 1 / r;
+}
+
+describe("getPresetsForGeometry", () => {
+    it("returns hyperbolic presets that satisfy the strict inequality", () => {
+        const presets = getPresetsForGeometry("hyperbolic");
+        expect(presets.length).toBeGreaterThan(0);
+        for (const preset of presets) {
+            const sum = reciprocalSum(preset.p, preset.q, preset.r);
+            expect(sum).toBeLessThan(1);
+        }
+    });
+
+    it("returns euclidean presets that are on the equality boundary", () => {
+        const presets = getPresetsForGeometry("euclidean");
+        expect(presets.length).toBeGreaterThan(0);
+        for (const preset of presets) {
+            const sum = reciprocalSum(preset.p, preset.q, preset.r);
+            expect(sum).toBeCloseTo(1, 12);
+        }
+    });
+});

--- a/tests/unit/ui/useTriangleParams.test.tsx
+++ b/tests/unit/ui/useTriangleParams.test.tsx
@@ -1,11 +1,11 @@
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { describe, expect, it } from "vitest";
-import type { TrianglePreset } from "../../../src/ui/hooks/useTriangleParams";
 import {
     type UseTriangleParamsOptions,
     useTriangleParams,
 } from "../../../src/ui/hooks/useTriangleParams";
+import type { TrianglePreset } from "../../../src/ui/trianglePresets";
 
 const globalActFlag = globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean };
 globalActFlag.IS_REACT_ACT_ENVIRONMENT = true;
@@ -81,12 +81,12 @@ describe("useTriangleParams", () => {
 
     it("locks p and q when anchor is set", () => {
         const harness = renderHook();
-        const preset: TrianglePreset = { label: "(3,3,3)", p: 3, q: 3, r: 3 };
+        const preset: TrianglePreset = { label: "(2,3,7)", p: 2, q: 3, r: 7 };
         harness.update((state) => {
             state.setFromPreset(preset);
             state.setParamInput("p", "5");
         });
-        expect(harness.current.formInputs.p).toBe("3");
+        expect(harness.current.formInputs.p).toBe(String(preset.p));
         harness.cleanup();
     });
 

--- a/tests/unit/ui/useTriangleParams.test.tsx
+++ b/tests/unit/ui/useTriangleParams.test.tsx
@@ -122,4 +122,14 @@ describe("useTriangleParams", () => {
         expect(harness.current.params.depth).toBe(5);
         harness.cleanup();
     });
+
+    it("switches to Euclidean preset when mode changes", () => {
+        const harness = renderHook();
+        harness.update((state) => {
+            state.setGeometryMode("euclidean");
+        });
+        expect(harness.current.geometryMode).toBe("euclidean");
+        expect(harness.current.formInputs).toMatchObject({ p: "3", q: "3", r: "3" });
+        harness.cleanup();
+    });
 });


### PR DESCRIPTION
Closes #93
Closes #96

## 目的（Why）
- 背景/課題: App 全体が Hyperbolic 前提のシーンのみで組まれており、Euclidean モードを選択しても描画・プリセット状態が破綻していた
- 目標: Euclidean モード専用のシーン構成と検証フローを用意し、プリセットや描画がモード切替に追随するようにする

## 変更点（What）
- `HyperbolicScene` / `EuclideanScene` を導入し、WebGL の半平面クリッピングと Canvas 描画をモードごとに切り替え
- Euclidean モードの半平面セット（SDF鏡）を構築し、円ディスク描画や WebGL 処理を非表示／スキップするフォールバックを追加
- Hyperbolic / Euclidean それぞれのプリセット表を `trianglePresets` として分離し、`useTriangleParams` と UI から独立して選択できるようにした
- プリセットの幾何条件とフック挙動を保証するユニットテストを追加

### 技術詳細（How）
- シーン構築処理を再分割し、モード切替後に適切なビルダー（`buildHyperbolicScene` / `buildEuclideanScene`）へ委譲
- Euclidean での描画失敗時は既定の半平面へフォールバックし、Hyperbolic の例外を UI 側で扱う土台を用意
- プリセット選択時はハイパボリックでのみスナップを有効にし、アンカー付きプリセットだけ既定値へ戻す挙動に調整

## スクリーンショット / 動作デモ（任意）
- N/A（ローカルで Euclidean / Hyperbolic 切替を確認済み）

## 受け入れ条件（DoD）
- [x] 目的を満たすユーザーストーリーが確認できる
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm run test:sandbox` が緑（coverage v8）
- [x] 重要分岐のユニット/プロパティテストが追加されている
- [ ] README/Docs/Storybook（該当時）が更新されている
- [x] アクセシビリティ: ラベル/フォーカス/キーボードが機能し重大違反なし

## 確認手順（Reviewer 向け）
```bash
pnpm i
pnpm lint && pnpm typecheck
pnpm test:sandbox tests/unit/ui/useTriangleParams.test.tsx
pnpm test:sandbox tests/unit/ui/presets.test.ts
# pre-push hook で `pnpm test:sandbox` フルスイート実行済み
pnpm dev
```

## リスクとロールバック
- 影響範囲: シーン構築 / レンダリングエンジン / プリセット UI
- リスク/懸念: プリセット表の更新漏れやシーン切替時の状態保持（#96で追跡）
- ロールバック指針: このPRを revert し、従来の単一シーン構成へ戻す

## Out of Scope（別PR）
- モード単位での state 完全分離と例外時フォールバックの最終設計（Refs #96）
- App.tsx の分割 Issue (#92) のテンプレ整備（別PR予定）

## 関連 Issue / PR
- Refs #96

## 追加メモ（任意）
- なし
