### PR TITLE
feat: enable shared half-plane control graph

### DIFF
--- a/tests/unit/geom/halfPlane.controls.test.ts
+++ b/tests/unit/geom/halfPlane.controls.test.ts
@@ -14,10 +14,13 @@ function length(v: Vec2): number {
 describe("halfPlaneControls", () => {
     it("derives a unit half-plane from two points", () => {
         const points: HalfPlaneControlPoints = [
-            { x: 0, y: 0 },
-            { x: 0, y: 1 },
+            { id: "p0", x: 0, y: 0, fixed: false },
+            { id: "p1", x: 0, y: 1, fixed: false },
         ];
-        const plane = deriveHalfPlaneFromPoints(points);
+        const plane = deriveHalfPlaneFromPoints([
+            { x: points[0].x, y: points[0].y },
+            { x: points[1].x, y: points[1].y },
+        ]);
         expect(length(plane.normal)).toBeCloseTo(1, 12);
         expect(plane.normal.x).toBeCloseTo(1, 12);
         expect(plane.normal.y).toBeCloseTo(0, 12);

--- a/tests/unit/ui/app.handles.test.tsx
+++ b/tests/unit/ui/app.handles.test.tsx
@@ -1,0 +1,66 @@
+import { createRoot } from "react-dom/client";
+import { act } from "react-dom/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import { App } from "@/ui/App";
+
+const renderMock = vi.fn();
+const disposeMock = vi.fn();
+
+vi.mock("@/render/engine", async () => {
+    const actual = await vi.importActual<typeof import("@/render/engine")>("@/render/engine");
+    return {
+        ...actual,
+        createRenderEngine: vi.fn(() => ({
+            render: renderMock,
+            dispose: disposeMock,
+            getMode: () => "canvas",
+        })),
+    };
+});
+
+describe("App handle rendering", () => {
+    it("sends handle overlay when enabled in Euclidean mode", async () => {
+        renderMock.mockClear();
+        const container = document.createElement("div");
+        document.body.appendChild(container);
+        const root = createRoot(container);
+        await act(async () => {
+            root.render(<App />);
+        });
+
+        const euclideanButton = Array.from(container.querySelectorAll("button")).find((btn) =>
+            btn.textContent?.toLowerCase().includes("euclidean"),
+        );
+        if (!euclideanButton) throw new Error("Euclidean mode button not found");
+        await act(async () => {
+            euclideanButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        });
+
+        const handleLabel = Array.from(container.querySelectorAll("label")).find((label) =>
+            label.textContent?.includes("Show control handles"),
+        );
+        if (!handleLabel) throw new Error("Handle toggle label not found");
+        const input = handleLabel.querySelector("input[type='checkbox']");
+        if (!input) throw new Error("Handle toggle input not found");
+        await act(async () => {
+            input.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        });
+
+        await act(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 0));
+        });
+
+        const calls = renderMock.mock.calls.map((call) => call[0]);
+        const finalCall = calls.at(-1);
+        expect(finalCall?.geometry).toBe("euclidean");
+        expect(finalCall?.handles?.visible).toBe(true);
+        const points = finalCall?.handles?.items?.[0]?.points;
+        expect(Array.isArray(points)).toBe(true);
+        expect(points?.length).toBeGreaterThan(0);
+
+        await act(async () => {
+            root.unmount();
+        });
+        container.remove();
+    });
+});


### PR DESCRIPTION
Closes #105

## 目的（Why）
- 背景/課題: ユークリッド半平面ハンドルは各線ごとに独立した2点しか持てず、ヒンジ共有構成を表現できなかった。
- 目標: 制御点を共有できるグラフ構造を導入し、ヒンジ型シーンの実装や今後の複数鏡シーン拡張に備える。

## 変更点（What）
- ControlPointId / ControlPoint などの新しいデータモデルを追加し、割り当て情報を扱えるようにした。
- halfPlaneControlPoints のドラッグ処理を共有IDと固定フラグ対応にリファクタリング。
- 共有制御点と固定ヒンジの動作を検証するユニットテストを追加。

### 技術詳細（How）
- 半平面→制御点変換時に割当てテーブルと registry を構築し、共有/固定制御点を1つのエントリで管理。
- updateControlPoint は対象IDを共有する全ポイントを一括更新し、fixed=true のハンドルでは即座に早期リターン。
- テストでは resetControlPointIdCounter でIDを決定論的にし、共有IDや固定ハンドルの挙動を網羅。

## スクリーンショット / 動作デモ（任意）
- なし（ロジックレベルの変更のみ）

## 受け入れ条件（DoD）
- [x] 目的を満たすユーザーストーリーが確認できる
- [x] `pnpm lint` / `pnpm typecheck` / `pnpm test` が緑（coverage v8）
- [x] 重要分岐のユニット/プロパティテストが追加されている
- [ ] README/Docs/Storybook（該当時）が更新されている
- [x] アクセシビリティ: ラベル/フォーカス/キーボードが機能し重大違反なし

## 確認手順（Reviewer 向け）
```bash
pnpm i
pnpm lint && pnpm typecheck && pnpm test
```

## リスクとロールバック
- 影響範囲: 半平面ハンドル制御ロジック全般（UI・Storybook）
- リスク/懸念: 共有IDの同期漏れにより既存三角形シーンに副作用が出る可能性
- ロールバック指針: このPRを revert して従来の独立制御点モデルへ戻す

## Out of Scope（別PR）
- ヒンジシーンのUI実装と Storybook 整備
- plane drag 再有効化や 4枚鏡シーンの導入

## 関連 Issue / PR
- Refs #104

## 追加メモ（任意）
- なし
