### PR TITLE
feat: extract scene hosts for triangle views

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,479 +1,52 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { GEOMETRY_KIND } from "@/geom/core/types";
-import type { HalfPlane } from "@/geom/primitives/halfPlane";
-import { normalizeHalfPlane } from "@/geom/primitives/halfPlane";
-import {
-    deriveHalfPlaneFromPoints,
-    derivePointsFromHalfPlane,
-    type HalfPlaneControlPoints,
-} from "@/geom/primitives/halfPlaneControls";
-import { buildEuclideanTriangle } from "@/geom/triangle/euclideanTriangle";
-import { screenToWorld } from "@/render/viewport";
-import { createRenderEngine, detectRenderMode, type RenderEngine } from "../render/engine";
-import type { Viewport } from "../render/viewport";
-import { DepthControls } from "./components/DepthControls";
-import { HalfPlaneHandleControls } from "./components/HalfPlaneHandleControls";
-import { ModeControls } from "./components/ModeControls";
-import { PresetSelector } from "./components/PresetSelector";
-import { SnapControls } from "./components/SnapControls";
-import { StageCanvas } from "./components/StageCanvas";
-import { TriangleParamForm } from "./components/TriangleParamForm";
+import { useMemo, useState } from "react";
+import { detectRenderMode, type RenderMode } from "@/render/engine";
 import { useTriangleParams } from "./hooks/useTriangleParams";
-import { nextOffsetOnDrag, pickHalfPlaneIndex } from "./interactions/euclideanHalfPlaneDrag";
 import {
-    controlPointsFromHalfPlanes,
-    hitTestControlPoints,
-    updateControlPoint,
-} from "./interactions/halfPlaneControlPoints";
-import { getPresetsForGeometry, type TrianglePreset } from "./trianglePresets";
+    DEFAULT_SCENE_ID,
+    getSceneDefinition,
+    listScenes,
+    type SceneDefinition,
+    type SceneId,
+} from "./scenes";
+import { TriangleSceneHost } from "./scenes/TriangleSceneHost";
 
 const TRIANGLE_N_MAX = 100;
 const INITIAL_PARAMS = { p: 2, q: 3, r: 7, depth: 2 } as const;
 const DEPTH_RANGE = { min: 0, max: 10 } as const;
-const HANDLE_DEFAULT_SPACING = 0.6;
-const HANDLE_HIT_TOLERANCE_PX = 10;
 
-type PlaneDragState = {
-    type: "plane";
-    pointerId: number;
-    index: number;
-    startOffset: number;
-    startScreen: { x: number; y: number };
-    normal: { x: number; y: number };
-};
-
-type HandleDragState = {
-    type: "handle";
-    pointerId: number;
-    planeIndex: number;
-    pointIndex: 0 | 1;
-};
-
-type DragState = PlaneDragState | HandleDragState;
-
-const DEFAULT_EUCLIDEAN_PLANES: HalfPlane[] = [
-    { normal: { x: 1, y: 0 }, offset: 0 },
-    { normal: { x: 0, y: 1 }, offset: 0 },
-    { normal: { x: -Math.SQRT1_2, y: Math.SQRT1_2 }, offset: 0 },
-];
+function useSceneRegistry(): {
+    scenes: SceneDefinition[];
+    triangleScenes: SceneDefinition[];
+} {
+    const scenes = useMemo(() => listScenes(), []);
+    const triangleScenes = useMemo(
+        () => scenes.filter((scene) => scene.category === "triangle"),
+        [scenes],
+    );
+    return { scenes, triangleScenes };
+}
 
 export function App(): JSX.Element {
-    const canvasRef = useRef<HTMLCanvasElement | null>(null);
-    const renderEngineRef = useRef<RenderEngine | null>(null);
-    const latestEuclideanPlanesRef = useRef<HalfPlane[] | null>(null);
-    const [renderMode] = useState(() => detectRenderMode());
-    const [editableHalfPlanes, setEditableHalfPlanes] = useState<HalfPlane[] | null>(null);
-    const [drag, setDrag] = useState<DragState | null>(null);
-    const [showHandles, setShowHandles] = useState(false);
-    const [handleSpacing, setHandleSpacing] = useState(HANDLE_DEFAULT_SPACING);
-    const [handleControls, setHandleControls] = useState<{
-        spacing: number;
-        points: HalfPlaneControlPoints[];
-    } | null>(null);
+    const [renderMode] = useState<RenderMode>(() => detectRenderMode());
+    const [selectedSceneId, setSelectedSceneId] = useState<SceneId>(DEFAULT_SCENE_ID);
+    const { triangleScenes } = useSceneRegistry();
+    const scene = useMemo(() => getSceneDefinition(selectedSceneId), [selectedSceneId]);
 
-    const {
-        params,
-        formInputs,
-        anchor,
-        snapEnabled,
-        paramError,
-        paramWarning,
-        rRange,
-        rSliderValue,
-        rStep,
-        depthRange,
-        geometryMode,
-        setParamInput,
-        setFromPreset,
-        clearAnchor,
-        setSnapEnabled: setSnapEnabledState,
-        setRFromSlider,
-        updateDepth,
-        setGeometryMode,
-    } = useTriangleParams({
+    const triangleParams = useTriangleParams({
         initialParams: INITIAL_PARAMS,
         triangleNMax: TRIANGLE_N_MAX,
         depthRange: DEPTH_RANGE,
+        initialGeometryMode: scene.geometry,
     });
 
-    const presets = useMemo<readonly TrianglePreset[]>(
-        () => getPresetsForGeometry(geometryMode),
-        [geometryMode],
-    );
-
-    useEffect(() => {
-        const canvas = canvasRef.current;
-        if (!canvas) return;
-        const engine = createRenderEngine(canvas, { mode: renderMode });
-        renderEngineRef.current = engine;
-        return () => {
-            renderEngineRef.current = null;
-            engine.dispose();
-        };
-    }, [renderMode]);
-
-    const euclideanHalfPlanes = useMemo(() => {
-        if (geometryMode !== GEOMETRY_KIND.euclidean || paramError) {
-            return null;
-        }
-        try {
-            const result = buildEuclideanTriangle(params.p, params.q, params.r);
-            return result.mirrors;
-        } catch {
-            return null;
-        }
-    }, [geometryMode, params, paramError]);
-
-    const normalizedHalfPlanes = useMemo(() => {
-        if (geometryMode !== GEOMETRY_KIND.euclidean) {
-            return null;
-        }
-        const base = editableHalfPlanes ?? euclideanHalfPlanes ?? DEFAULT_EUCLIDEAN_PLANES;
-        if (!base) return null;
-        return base.map((plane) => normalizeHalfPlane(plane));
-    }, [geometryMode, editableHalfPlanes, euclideanHalfPlanes]);
-
-    const editingKey = `${geometryMode}:${params.p}:${params.q}:${params.r}`;
-    // Reset editing state when parameters or mode change
-    useEffect(() => {
-        void editingKey; // mark dependency usage for linter
-        setEditableHalfPlanes(null);
-        setDrag(null);
-        setHandleControls(null);
-    }, [editingKey]);
-
-    const computeViewport = (canvas: HTMLCanvasElement): Viewport => {
-        const rect = canvas.getBoundingClientRect();
-        const width = rect.width || canvas.width || 1;
-        const height = rect.height || canvas.height || 1;
-        const size = Math.min(width, height);
-        const margin = 8;
-        const scale = Math.max(1, size / 2 - margin);
-        return { scale, tx: width / 2, ty: height / 2 };
-    };
-
-    useEffect(() => {
-        if (!showHandles) {
-            setHandleControls(null);
-            return;
-        }
-        if (!normalizedHalfPlanes) {
-            setHandleControls(null);
-            return;
-        }
-        setHandleControls((prev) => {
-            if (
-                !prev ||
-                prev.points.length !== normalizedHalfPlanes.length ||
-                prev.spacing !== handleSpacing
-            ) {
-                return {
-                    spacing: handleSpacing,
-                    points: controlPointsFromHalfPlanes(normalizedHalfPlanes, handleSpacing),
-                };
-            }
-            return prev;
-        });
-    }, [showHandles, handleSpacing, normalizedHalfPlanes]);
-
-    const getPointer = (e: React.PointerEvent<HTMLCanvasElement>) => {
-        const rect = e.currentTarget.getBoundingClientRect();
-        return {
-            x: e.clientX - rect.left,
-            y: e.clientY - rect.top,
-        };
-    };
-
-    const currentControlPoints = handleControls?.points ?? null;
-    const activeHandle =
-        drag?.type === "handle"
-            ? { planeIndex: drag.planeIndex, pointIndex: drag.pointIndex }
-            : null;
-
-    const renderEuclideanScene = useCallback(
-        (
-            planes: HalfPlane[],
-            overridePoints?: HalfPlaneControlPoints[] | null,
-            overrideActive?: { planeIndex: number; pointIndex: 0 | 1 } | null,
-        ) => {
-            const handlePoints = overridePoints ?? currentControlPoints;
-            const active = overrideActive ?? activeHandle;
-            const handles =
-                showHandles && handlePoints
-                    ? {
-                          visible: true,
-                          items: handlePoints.map((points, idx) => ({ planeIndex: idx, points })),
-                          active: active ?? null,
-                      }
-                    : undefined;
-            latestEuclideanPlanesRef.current = planes;
-            renderEngineRef.current?.render({
-                geometry: GEOMETRY_KIND.euclidean,
-                halfPlanes: planes,
-                handles,
-            });
-        },
-        [activeHandle, currentControlPoints, showHandles],
-    );
-
-    const handlePointerDown = (e: React.PointerEvent<HTMLCanvasElement>) => {
-        if (geometryMode !== GEOMETRY_KIND.euclidean || !normalizedHalfPlanes) return;
-        const canvas = e.currentTarget;
-        const viewport = computeViewport(canvas);
-        const screen = getPointer(e);
-
-        if (
-            showHandles &&
-            currentControlPoints &&
-            currentControlPoints.length === normalizedHalfPlanes.length
-        ) {
-            const hit = hitTestControlPoints(
-                currentControlPoints,
-                viewport,
-                screen,
-                HANDLE_HIT_TOLERANCE_PX,
-            );
-            if (hit) {
-                try {
-                    canvas.setPointerCapture(e.pointerId);
-                } catch {
-                    // ignore
-                }
-                const worldPoint = screenToWorld(viewport, screen);
-                const nextPoints = updateControlPoint(
-                    currentControlPoints,
-                    hit.planeIndex,
-                    hit.pointIndex,
-                    worldPoint,
-                );
-                const nextPlanes = normalizedHalfPlanes.map((plane, idx) =>
-                    idx === hit.planeIndex ? deriveHalfPlaneFromPoints(nextPoints[idx]) : plane,
-                );
-                setEditableHalfPlanes(nextPlanes);
-                setHandleControls({ spacing: handleSpacing, points: nextPoints });
-                setDrag({
-                    type: "handle",
-                    pointerId: e.pointerId,
-                    planeIndex: hit.planeIndex,
-                    pointIndex: hit.pointIndex,
-                });
-                renderEuclideanScene(nextPlanes, nextPoints, hit);
-                return;
-            }
-        }
-
-        const idx = pickHalfPlaneIndex(normalizedHalfPlanes, viewport, screen, 8);
-        if (idx < 0) return;
-        const unit = normalizedHalfPlanes[idx];
-        try {
-            canvas.setPointerCapture(e.pointerId);
-        } catch {
-            // ignore
-        }
-        const p0 = screenToWorld(viewport, screen);
-        const snappedStartOffset = -(unit.normal.x * p0.x + unit.normal.y * p0.y);
-        const updatedPlanes = normalizedHalfPlanes.map((plane, i) =>
-            i === idx ? { normal: plane.normal, offset: snappedStartOffset } : plane,
-        );
-        setEditableHalfPlanes(updatedPlanes);
-        if (showHandles) {
-            setHandleControls((prev) => {
-                if (!prev || prev.points.length !== updatedPlanes.length) {
-                    return {
-                        spacing: handleSpacing,
-                        points: controlPointsFromHalfPlanes(updatedPlanes, handleSpacing),
-                    };
-                }
-                const nextPoints = prev.points.map((points, planeIndex) =>
-                    planeIndex === idx
-                        ? derivePointsFromHalfPlane(updatedPlanes[planeIndex], prev.spacing)
-                        : points,
-                ) as HalfPlaneControlPoints[];
-                return { spacing: prev.spacing, points: nextPoints };
-            });
-        }
-        renderEuclideanScene(updatedPlanes);
-        setDrag({
-            type: "plane",
-            pointerId: e.pointerId,
-            index: idx,
-            startOffset: snappedStartOffset,
-            startScreen: screen,
-            normal: unit.normal,
-        });
-    };
-
-    const handlePointerMove = (e: React.PointerEvent<HTMLCanvasElement>) => {
-        if (!drag || geometryMode !== GEOMETRY_KIND.euclidean) return;
-        const canvas = e.currentTarget;
-        const viewport = computeViewport(canvas);
-
-        if (drag.type === "plane") {
-            const cur = getPointer(e);
-            const nextOffset = nextOffsetOnDrag(
-                drag.normal,
-                drag.startOffset,
-                viewport,
-                drag.startScreen,
-                cur,
-            );
-            let updatedPlanes: HalfPlane[] | null = null;
-            setEditableHalfPlanes((prev) => {
-                const basePlanes = (prev ?? normalizedHalfPlanes ?? DEFAULT_EUCLIDEAN_PLANES).map(
-                    (plane) => normalizeHalfPlane(plane),
-                );
-                updatedPlanes = basePlanes.map((plane, idx) =>
-                    idx === drag.index ? { normal: plane.normal, offset: nextOffset } : plane,
-                );
-                return updatedPlanes;
-            });
-            if (!updatedPlanes) return;
-            const resolvedPlanes: HalfPlane[] = updatedPlanes;
-            let nextPointsForRender: HalfPlaneControlPoints[] | null = currentControlPoints;
-            if (showHandles) {
-                setHandleControls((prev) => {
-                    if (!prev || prev.points.length !== resolvedPlanes.length) {
-                        const points = controlPointsFromHalfPlanes(resolvedPlanes, handleSpacing);
-                        nextPointsForRender = points;
-                        return { spacing: handleSpacing, points };
-                    }
-                    const points = prev.points.map((pts, idx) =>
-                        idx === drag.index
-                            ? derivePointsFromHalfPlane(resolvedPlanes[idx], prev.spacing)
-                            : pts,
-                    ) as HalfPlaneControlPoints[];
-                    nextPointsForRender = points;
-                    return { spacing: prev.spacing, points };
-                });
-            }
-            renderEuclideanScene(resolvedPlanes, nextPointsForRender, null);
-            return;
-        }
-
-        // handle drag
-        const world = screenToWorld(viewport, getPointer(e));
-        let nextPoints: HalfPlaneControlPoints[] | null = null;
-        setHandleControls((prev) => {
-            if (!prev) return prev;
-            const updatedPoints = updateControlPoint(
-                prev.points,
-                drag.planeIndex,
-                drag.pointIndex,
-                world,
-            );
-            nextPoints = updatedPoints;
-            return { spacing: prev.spacing, points: updatedPoints };
-        });
-        if (!nextPoints) return;
-        let updatedPlanes: HalfPlane[] | null = null;
-        setEditableHalfPlanes((prev) => {
-            const basePlanes = (prev ?? normalizedHalfPlanes ?? DEFAULT_EUCLIDEAN_PLANES).map(
-                (plane) => normalizeHalfPlane(plane),
-            );
-            updatedPlanes = basePlanes.map((plane, idx) =>
-                idx === drag.planeIndex && nextPoints
-                    ? deriveHalfPlaneFromPoints(nextPoints[idx])
-                    : plane,
-            );
-            return updatedPlanes;
-        });
-        if (!updatedPlanes) return;
-        renderEuclideanScene(updatedPlanes, nextPoints, {
-            planeIndex: drag.planeIndex,
-            pointIndex: drag.pointIndex,
-        });
-    };
-
-    const handlePointerUpOrCancel = (e: React.PointerEvent<HTMLCanvasElement>) => {
-        if (drag) {
-            try {
-                e.currentTarget.releasePointerCapture(drag.pointerId);
-            } catch {
-                // ignore
-            }
-        }
-        setDrag(null);
-        if (geometryMode === GEOMETRY_KIND.euclidean) {
-            const planes = latestEuclideanPlanesRef.current ?? normalizedHalfPlanes ?? null;
-            if (planes) {
-                renderEuclideanScene(planes, currentControlPoints, null);
-            }
-        }
-    };
-
-    useEffect(() => {
-        if (geometryMode === GEOMETRY_KIND.hyperbolic) {
-            latestEuclideanPlanesRef.current = null;
-            renderEngineRef.current?.render({ geometry: GEOMETRY_KIND.hyperbolic, params });
-            return;
-        }
-        if (!normalizedHalfPlanes) return;
-        renderEuclideanScene(normalizedHalfPlanes, currentControlPoints, null);
-    }, [geometryMode, params, normalizedHalfPlanes, currentControlPoints, renderEuclideanScene]);
-
     return (
-        <div
-            style={{
-                boxSizing: "border-box",
-                display: "grid",
-                gap: "16px",
-                gridTemplateColumns: "minmax(220px, 320px) 1fr",
-                height: "100%",
-                padding: "16px",
-                width: "100%",
-            }}
-        >
-            <div style={{ display: "grid", gap: "12px", alignContent: "start" }}>
-                <h2 style={{ margin: 0, fontSize: "1.1rem" }}>Triangle Parameters</h2>
-                <PresetSelector
-                    presets={presets}
-                    anchor={anchor}
-                    onSelect={setFromPreset}
-                    onClear={clearAnchor}
-                />
-                <ModeControls
-                    geometryMode={geometryMode}
-                    onGeometryChange={setGeometryMode}
-                    renderBackend={renderMode}
-                />
-                <SnapControls snapEnabled={snapEnabled} onToggle={setSnapEnabledState} />
-                <HalfPlaneHandleControls
-                    showHandles={showHandles}
-                    onToggle={setShowHandles}
-                    spacing={handleSpacing}
-                    onSpacingChange={setHandleSpacing}
-                    disabled={geometryMode !== GEOMETRY_KIND.euclidean}
-                />
-                <TriangleParamForm
-                    formInputs={formInputs}
-                    params={params}
-                    anchor={anchor}
-                    paramError={paramError}
-                    paramWarning={paramWarning}
-                    geometryMode={geometryMode}
-                    rRange={rRange}
-                    rStep={rStep}
-                    rSliderValue={rSliderValue}
-                    onParamChange={setParamInput}
-                    onRSliderChange={setRFromSlider}
-                />
-                <DepthControls
-                    depth={params.depth}
-                    depthRange={depthRange}
-                    onDepthChange={updateDepth}
-                />
-            </div>
-            <div style={{ display: "grid", placeItems: "center" }}>
-                <StageCanvas
-                    ref={canvasRef}
-                    width={800}
-                    height={600}
-                    onPointerDown={handlePointerDown}
-                    onPointerMove={handlePointerMove}
-                    onPointerUp={handlePointerUpOrCancel}
-                    onPointerCancel={handlePointerUpOrCancel}
-                />
-            </div>
-        </div>
+        <TriangleSceneHost
+            scene={scene}
+            scenes={triangleScenes}
+            activeSceneId={selectedSceneId}
+            onSceneChange={setSelectedSceneId}
+            renderMode={renderMode}
+            triangle={triangleParams}
+        />
     );
 }

--- a/src/ui/components/ModeControls.tsx
+++ b/src/ui/components/ModeControls.tsx
@@ -1,33 +1,30 @@
-import type { GeometryKind } from "@/geom/core/types";
-import { GEOMETRY_KIND } from "@/geom/core/types";
-import type { GeometryMode } from "../hooks/useTriangleParams";
+import type { SceneDefinition, SceneId } from "@/ui/scenes";
 
 export type ModeControlsProps = {
-    geometryMode: GeometryMode;
-    onGeometryChange: (mode: GeometryMode) => void;
+    scenes: SceneDefinition[];
+    activeSceneId: SceneId;
+    onSceneChange: (sceneId: SceneId) => void;
     renderBackend: string;
 };
 
-const MODES: GeometryMode[] = [GEOMETRY_KIND.hyperbolic, GEOMETRY_KIND.euclidean];
-
-const LABELS: Record<GeometryKind, string> = {
-    [GEOMETRY_KIND.hyperbolic]: "Hyperbolic",
-    [GEOMETRY_KIND.euclidean]: "Euclidean",
-};
-
-export function ModeControls({ geometryMode, onGeometryChange, renderBackend }: ModeControlsProps) {
+export function ModeControls({
+    scenes,
+    activeSceneId,
+    onSceneChange,
+    renderBackend,
+}: ModeControlsProps) {
     return (
         <div style={{ display: "grid", gap: "8px" }}>
             <div style={{ display: "grid", gap: "4px" }}>
-                <span style={{ fontWeight: 600 }}>Geometry Mode</span>
+                <span style={{ fontWeight: 600 }}>Scene</span>
                 <div style={{ display: "flex", flexWrap: "wrap", gap: "8px" }}>
-                    {MODES.map((mode) => {
-                        const active = mode === geometryMode;
+                    {scenes.map((scene) => {
+                        const active = scene.id === activeSceneId;
                         return (
                             <button
-                                key={mode}
+                                key={scene.id}
                                 type="button"
-                                onClick={() => onGeometryChange(mode)}
+                                onClick={() => onSceneChange(scene.id)}
                                 style={{
                                     padding: "4px 8px",
                                     border: active ? "1px solid #4a90e2" : "1px solid #bbb",
@@ -35,7 +32,7 @@ export function ModeControls({ geometryMode, onGeometryChange, renderBackend }: 
                                     cursor: "pointer",
                                 }}
                             >
-                                {LABELS[mode]}
+                                {scene.label}
                             </button>
                         );
                     })}

--- a/src/ui/scenes/TriangleSceneHost.tsx
+++ b/src/ui/scenes/TriangleSceneHost.tsx
@@ -1,0 +1,508 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { GEOMETRY_KIND } from "@/geom/core/types";
+import type { HalfPlane } from "@/geom/primitives/halfPlane";
+import { normalizeHalfPlane } from "@/geom/primitives/halfPlane";
+import {
+    controlPointsFromHalfPlanes,
+    deriveHalfPlaneFromPoints,
+    derivePointsFromHalfPlane,
+    type HalfPlaneControlPoints,
+} from "@/geom/primitives/halfPlaneControls";
+import { buildEuclideanTriangle } from "@/geom/triangle/euclideanTriangle";
+import { createRenderEngine, type RenderEngine, type RenderMode } from "@/render/engine";
+import type { Viewport } from "@/render/viewport";
+import { screenToWorld } from "@/render/viewport";
+import { DepthControls } from "@/ui/components/DepthControls";
+import { HalfPlaneHandleControls } from "@/ui/components/HalfPlaneHandleControls";
+import { ModeControls } from "@/ui/components/ModeControls";
+import { PresetSelector } from "@/ui/components/PresetSelector";
+import { SnapControls } from "@/ui/components/SnapControls";
+import { StageCanvas } from "@/ui/components/StageCanvas";
+import { TriangleParamForm } from "@/ui/components/TriangleParamForm";
+import { nextOffsetOnDrag, pickHalfPlaneIndex } from "@/ui/interactions/euclideanHalfPlaneDrag";
+import { hitTestControlPoints, updateControlPoint } from "@/ui/interactions/halfPlaneControlPoints";
+import { getPresetsForGeometry, type TrianglePreset } from "@/ui/trianglePresets";
+import type { UseTriangleParamsResult } from "../hooks/useTriangleParams";
+import type { SceneDefinition, SceneId } from "./types";
+
+const HANDLE_DEFAULT_SPACING = 0.6;
+const HANDLE_HIT_TOLERANCE_PX = 10;
+
+const DEFAULT_EUCLIDEAN_PLANES: HalfPlane[] = [
+    { normal: { x: 1, y: 0 }, offset: 0 },
+    { normal: { x: 0, y: 1 }, offset: 0 },
+    { normal: { x: -Math.SQRT1_2, y: Math.SQRT1_2 }, offset: 0 },
+];
+
+type PlaneDragState = {
+    type: "plane";
+    pointerId: number;
+    index: number;
+    startOffset: number;
+    startScreen: { x: number; y: number };
+    normal: { x: number; y: number };
+};
+
+type HandleDragState = {
+    type: "handle";
+    pointerId: number;
+    planeIndex: number;
+    pointIndex: 0 | 1;
+};
+
+type DragState = PlaneDragState | HandleDragState;
+
+type TriangleSceneHostProps = {
+    scene: SceneDefinition;
+    scenes: SceneDefinition[];
+    activeSceneId: SceneId;
+    onSceneChange: (id: SceneId) => void;
+    renderMode: RenderMode;
+    triangle: UseTriangleParamsResult;
+};
+
+type HandleControlsState = {
+    spacing: number;
+    points: HalfPlaneControlPoints[];
+};
+
+export function TriangleSceneHost({
+    scene,
+    scenes,
+    activeSceneId,
+    onSceneChange,
+    renderMode,
+    triangle,
+}: TriangleSceneHostProps): JSX.Element {
+    const canvasRef = useRef<HTMLCanvasElement | null>(null);
+    const renderEngineRef = useRef<RenderEngine | null>(null);
+    const latestEuclideanPlanesRef = useRef<HalfPlane[] | null>(null);
+    const [editableHalfPlanes, setEditableHalfPlanes] = useState<HalfPlane[] | null>(null);
+    const [drag, setDrag] = useState<DragState | null>(null);
+    const [showHandles, setShowHandles] = useState(false);
+    const [handleSpacing, setHandleSpacing] = useState(HANDLE_DEFAULT_SPACING);
+    const [handleControls, setHandleControls] = useState<HandleControlsState | null>(null);
+
+    const {
+        params,
+        formInputs,
+        anchor,
+        snapEnabled,
+        paramError,
+        paramWarning,
+        rRange,
+        rSliderValue,
+        rStep,
+        depthRange,
+        geometryMode,
+        setParamInput,
+        setFromPreset,
+        clearAnchor,
+        setSnapEnabled,
+        setRFromSlider,
+        updateDepth,
+        setGeometryMode,
+    } = triangle;
+
+    useEffect(() => {
+        if (geometryMode !== scene.geometry) {
+            setGeometryMode(scene.geometry);
+        }
+    }, [geometryMode, scene.geometry, setGeometryMode]);
+
+    const presets = useMemo<readonly TrianglePreset[]>(
+        () => getPresetsForGeometry(scene.geometry),
+        [scene.geometry],
+    );
+
+    useEffect(() => {
+        const canvas = canvasRef.current;
+        if (!canvas) return;
+        const engine = createRenderEngine(canvas, { mode: renderMode });
+        renderEngineRef.current = engine;
+        return () => {
+            renderEngineRef.current = null;
+            engine.dispose();
+        };
+    }, [renderMode]);
+
+    const euclideanHalfPlanes = useMemo(() => {
+        if (scene.geometry !== GEOMETRY_KIND.euclidean || paramError) {
+            return null;
+        }
+        try {
+            const result = buildEuclideanTriangle(params.p, params.q, params.r);
+            return result.mirrors;
+        } catch {
+            return null;
+        }
+    }, [scene.geometry, params, paramError]);
+
+    const normalizedHalfPlanes = useMemo(() => {
+        if (scene.geometry !== GEOMETRY_KIND.euclidean) {
+            return null;
+        }
+        const base = editableHalfPlanes ?? euclideanHalfPlanes ?? DEFAULT_EUCLIDEAN_PLANES;
+        if (!base) return null;
+        return base.map((plane) => normalizeHalfPlane(plane));
+    }, [scene.geometry, editableHalfPlanes, euclideanHalfPlanes]);
+
+    const editingKey = `${scene.id}:${params.p}:${params.q}:${params.r}`;
+    useEffect(() => {
+        void editingKey;
+        setEditableHalfPlanes(null);
+        setDrag(null);
+        setHandleControls(null);
+    }, [editingKey]);
+
+    const computeViewport = (canvas: HTMLCanvasElement): Viewport => {
+        const rect = canvas.getBoundingClientRect();
+        const width = rect.width || canvas.width || 1;
+        const height = rect.height || canvas.height || 1;
+        const size = Math.min(width, height);
+        const margin = 8;
+        const scale = Math.max(1, size / 2 - margin);
+        return { scale, tx: width / 2, ty: height / 2 };
+    };
+
+    useEffect(() => {
+        if (!scene.supportsHandles || !showHandles) {
+            setHandleControls(null);
+            return;
+        }
+        if (!normalizedHalfPlanes) {
+            setHandleControls(null);
+            return;
+        }
+        setHandleControls((prev) => {
+            if (
+                !prev ||
+                prev.points.length !== normalizedHalfPlanes.length ||
+                prev.spacing !== handleSpacing
+            ) {
+                return {
+                    spacing: handleSpacing,
+                    points: controlPointsFromHalfPlanes(normalizedHalfPlanes, handleSpacing),
+                };
+            }
+            return prev;
+        });
+    }, [scene.supportsHandles, showHandles, handleSpacing, normalizedHalfPlanes]);
+
+    const getPointer = (e: React.PointerEvent<HTMLCanvasElement>) => {
+        const rect = e.currentTarget.getBoundingClientRect();
+        return {
+            x: e.clientX - rect.left,
+            y: e.clientY - rect.top,
+        };
+    };
+
+    const currentControlPoints = handleControls?.points ?? null;
+    const activeHandle =
+        drag?.type === "handle"
+            ? { planeIndex: drag.planeIndex, pointIndex: drag.pointIndex }
+            : null;
+
+    const renderEuclideanScene = useCallback(
+        (
+            planes: HalfPlane[],
+            overridePoints?: HalfPlaneControlPoints[] | null,
+            overrideActive?: { planeIndex: number; pointIndex: 0 | 1 } | null,
+        ) => {
+            const handlePoints = overridePoints ?? currentControlPoints;
+            const active = overrideActive ?? activeHandle;
+            const handles =
+                scene.supportsHandles && showHandles && handlePoints
+                    ? {
+                          visible: true,
+                          items: handlePoints.map((points, idx) => ({ planeIndex: idx, points })),
+                          active: active ?? null,
+                      }
+                    : undefined;
+            latestEuclideanPlanesRef.current = planes;
+            renderEngineRef.current?.render({
+                geometry: GEOMETRY_KIND.euclidean,
+                halfPlanes: planes,
+                handles,
+            });
+        },
+        [activeHandle, currentControlPoints, scene.supportsHandles, showHandles],
+    );
+
+    const renderHyperbolicScene = useCallback(() => {
+        renderEngineRef.current?.render({ geometry: GEOMETRY_KIND.hyperbolic, params });
+    }, [params]);
+
+    const handlePointerDown = (e: React.PointerEvent<HTMLCanvasElement>) => {
+        if (scene.geometry !== GEOMETRY_KIND.euclidean || !normalizedHalfPlanes) return;
+        const canvas = e.currentTarget;
+        const viewport = computeViewport(canvas);
+        const screen = getPointer(e);
+
+        if (
+            scene.supportsHandles &&
+            showHandles &&
+            currentControlPoints &&
+            currentControlPoints.length === normalizedHalfPlanes.length
+        ) {
+            const hit = hitTestControlPoints(
+                currentControlPoints,
+                viewport,
+                screen,
+                HANDLE_HIT_TOLERANCE_PX,
+            );
+            if (hit) {
+                try {
+                    canvas.setPointerCapture(e.pointerId);
+                } catch {
+                    // ignore
+                }
+                const worldPoint = screenToWorld(viewport, screen);
+                const nextPoints = updateControlPoint(
+                    currentControlPoints,
+                    hit.planeIndex,
+                    hit.pointIndex,
+                    worldPoint,
+                );
+                const nextPlanes = normalizedHalfPlanes.map((plane, idx) =>
+                    idx === hit.planeIndex ? deriveHalfPlaneFromPoints(nextPoints[idx]) : plane,
+                );
+                setEditableHalfPlanes(nextPlanes);
+                setHandleControls({ spacing: handleSpacing, points: nextPoints });
+                setDrag({
+                    type: "handle",
+                    pointerId: e.pointerId,
+                    planeIndex: hit.planeIndex,
+                    pointIndex: hit.pointIndex,
+                });
+                renderEuclideanScene(nextPlanes, nextPoints, hit);
+                return;
+            }
+        }
+
+        const idx = pickHalfPlaneIndex(normalizedHalfPlanes, viewport, screen, 8);
+        if (idx < 0) return;
+        const unit = normalizedHalfPlanes[idx];
+        try {
+            canvas.setPointerCapture(e.pointerId);
+        } catch {
+            // ignore
+        }
+        const p0 = screenToWorld(viewport, screen);
+        const snappedStartOffset = -(unit.normal.x * p0.x + unit.normal.y * p0.y);
+        const updatedPlanes = normalizedHalfPlanes.map((plane, i) =>
+            i === idx ? { normal: plane.normal, offset: snappedStartOffset } : plane,
+        );
+        setEditableHalfPlanes(updatedPlanes);
+        if (scene.supportsHandles && showHandles) {
+            setHandleControls((prev) => {
+                if (!prev || prev.points.length !== updatedPlanes.length) {
+                    return {
+                        spacing: handleSpacing,
+                        points: controlPointsFromHalfPlanes(updatedPlanes, handleSpacing),
+                    };
+                }
+                const nextPoints = prev.points.map((points, planeIndex) =>
+                    planeIndex === idx
+                        ? derivePointsFromHalfPlane(updatedPlanes[planeIndex], prev.spacing)
+                        : points,
+                ) as HalfPlaneControlPoints[];
+                return { spacing: prev.spacing, points: nextPoints };
+            });
+        }
+        renderEuclideanScene(updatedPlanes);
+        setDrag({
+            type: "plane",
+            pointerId: e.pointerId,
+            index: idx,
+            startOffset: snappedStartOffset,
+            startScreen: screen,
+            normal: unit.normal,
+        });
+    };
+
+    const handlePointerMove = (e: React.PointerEvent<HTMLCanvasElement>) => {
+        if (!drag || scene.geometry !== GEOMETRY_KIND.euclidean) return;
+        const canvas = e.currentTarget;
+        const viewport = computeViewport(canvas);
+
+        if (drag.type === "plane") {
+            const cur = getPointer(e);
+            const nextOffset = nextOffsetOnDrag(
+                drag.normal,
+                drag.startOffset,
+                viewport,
+                drag.startScreen,
+                cur,
+            );
+            let updatedPlanes: HalfPlane[] | null = null;
+            setEditableHalfPlanes((prev) => {
+                const basePlanes = (prev ?? normalizedHalfPlanes ?? DEFAULT_EUCLIDEAN_PLANES).map(
+                    (plane) => normalizeHalfPlane(plane),
+                );
+                updatedPlanes = basePlanes.map((plane, idx) =>
+                    idx === drag.index ? { normal: plane.normal, offset: nextOffset } : plane,
+                );
+                return updatedPlanes;
+            });
+            if (!updatedPlanes) return;
+            const resolvedPlanes: HalfPlane[] = updatedPlanes;
+            let nextPointsForRender: HalfPlaneControlPoints[] | null = currentControlPoints;
+            if (scene.supportsHandles && showHandles) {
+                setHandleControls((prev) => {
+                    if (!prev || prev.points.length !== resolvedPlanes.length) {
+                        const points = controlPointsFromHalfPlanes(resolvedPlanes, handleSpacing);
+                        nextPointsForRender = points;
+                        return { spacing: handleSpacing, points };
+                    }
+                    const points = prev.points.map((pts, idx) =>
+                        idx === drag.index
+                            ? derivePointsFromHalfPlane(resolvedPlanes[idx], prev.spacing)
+                            : pts,
+                    ) as HalfPlaneControlPoints[];
+                    nextPointsForRender = points;
+                    return { spacing: prev.spacing, points };
+                });
+            }
+            renderEuclideanScene(resolvedPlanes, nextPointsForRender, {
+                planeIndex: drag.index,
+                pointIndex: 0,
+            });
+            return;
+        }
+
+        // handle drag
+        const world = screenToWorld(viewport, getPointer(e));
+        let nextPoints: HalfPlaneControlPoints[] | null = null;
+        setHandleControls((prev) => {
+            if (!prev) return prev;
+            const updatedPoints = updateControlPoint(
+                prev.points,
+                drag.planeIndex,
+                drag.pointIndex,
+                world,
+            );
+            nextPoints = updatedPoints;
+            return { spacing: prev.spacing, points: updatedPoints };
+        });
+        if (!nextPoints) return;
+        let updatedPlanes: HalfPlane[] | null = null;
+        setEditableHalfPlanes((prev) => {
+            const basePlanes = (prev ?? normalizedHalfPlanes ?? DEFAULT_EUCLIDEAN_PLANES).map(
+                (plane) => normalizeHalfPlane(plane),
+            );
+            updatedPlanes = basePlanes.map((plane, idx) =>
+                idx === drag.planeIndex && nextPoints
+                    ? deriveHalfPlaneFromPoints(nextPoints[idx])
+                    : plane,
+            );
+            return updatedPlanes;
+        });
+        if (!updatedPlanes) return;
+        renderEuclideanScene(updatedPlanes, nextPoints, {
+            planeIndex: drag.planeIndex,
+            pointIndex: drag.pointIndex,
+        });
+    };
+
+    const handlePointerUpOrCancel = (e: React.PointerEvent<HTMLCanvasElement>) => {
+        if (drag) {
+            try {
+                e.currentTarget.releasePointerCapture(drag.pointerId);
+            } catch {
+                // ignore
+            }
+        }
+        setDrag(null);
+        if (scene.geometry === GEOMETRY_KIND.euclidean) {
+            const planes = latestEuclideanPlanesRef.current ?? normalizedHalfPlanes ?? null;
+            if (planes) {
+                renderEuclideanScene(planes, currentControlPoints, null);
+            }
+        }
+    };
+
+    useEffect(() => {
+        if (scene.geometry === GEOMETRY_KIND.hyperbolic) {
+            latestEuclideanPlanesRef.current = null;
+            renderHyperbolicScene();
+            return;
+        }
+        if (!normalizedHalfPlanes) return;
+        renderEuclideanScene(normalizedHalfPlanes, currentControlPoints, null);
+    }, [
+        scene.geometry,
+        normalizedHalfPlanes,
+        currentControlPoints,
+        renderEuclideanScene,
+        renderHyperbolicScene,
+    ]);
+
+    return (
+        <div
+            style={{
+                boxSizing: "border-box",
+                display: "grid",
+                gap: "16px",
+                gridTemplateColumns: "minmax(220px, 320px) 1fr",
+                height: "100%",
+                padding: "16px",
+                width: "100%",
+            }}
+        >
+            <div style={{ display: "grid", gap: "12px", alignContent: "start" }}>
+                <ModeControls
+                    scenes={scenes}
+                    activeSceneId={activeSceneId}
+                    onSceneChange={onSceneChange}
+                    renderBackend={renderMode}
+                />
+                <PresetSelector
+                    presets={presets as TrianglePreset[]}
+                    anchor={anchor}
+                    onSelect={setFromPreset}
+                    onClear={clearAnchor}
+                />
+                <SnapControls snapEnabled={snapEnabled} onToggle={setSnapEnabled} />
+                {scene.supportsHandles && (
+                    <HalfPlaneHandleControls
+                        showHandles={showHandles}
+                        onToggle={setShowHandles}
+                        spacing={handleSpacing}
+                        onSpacingChange={setHandleSpacing}
+                        disabled={scene.geometry !== GEOMETRY_KIND.euclidean}
+                    />
+                )}
+                <TriangleParamForm
+                    formInputs={formInputs}
+                    params={params}
+                    anchor={anchor}
+                    paramError={paramError}
+                    paramWarning={paramWarning}
+                    geometryMode={scene.geometry}
+                    rRange={rRange}
+                    rStep={rStep}
+                    rSliderValue={rSliderValue}
+                    onParamChange={setParamInput}
+                    onRSliderChange={setRFromSlider}
+                />
+                <DepthControls
+                    depth={params.depth}
+                    depthRange={depthRange}
+                    onDepthChange={updateDepth}
+                />
+            </div>
+            <div style={{ display: "grid", placeItems: "center" }}>
+                <StageCanvas
+                    ref={canvasRef}
+                    width={800}
+                    height={600}
+                    onPointerDown={handlePointerDown}
+                    onPointerMove={handlePointerMove}
+                    onPointerUp={handlePointerUpOrCancel}
+                    onPointerCancel={handlePointerUpOrCancel}
+                />
+            </div>
+        </div>
+    );
+}

--- a/src/ui/scenes/index.ts
+++ b/src/ui/scenes/index.ts
@@ -1,0 +1,3 @@
+export * from "./registry";
+export * from "./triangleScenes";
+export * from "./types";

--- a/src/ui/scenes/registry.ts
+++ b/src/ui/scenes/registry.ts
@@ -1,0 +1,36 @@
+import {
+    DEFAULT_TRIANGLE_SCENE_ID,
+    TRIANGLE_SCENE_IDS,
+    TRIANGLE_SCENE_ORDER,
+    TRIANGLE_SCENES,
+} from "./triangleScenes";
+import type { SceneDefinition, SceneId, SceneRegistry } from "./types";
+
+const SCENE_MAP: Record<SceneId, SceneDefinition> = {
+    ...TRIANGLE_SCENES,
+};
+
+const SCENE_ORDER: SceneId[] = [...TRIANGLE_SCENE_ORDER];
+
+export const DEFAULT_SCENE_ID: SceneId = DEFAULT_TRIANGLE_SCENE_ID;
+
+export const SCENE_REGISTRY: SceneRegistry = {
+    byId: SCENE_MAP,
+    order: SCENE_ORDER,
+};
+
+export function listScenes(): SceneDefinition[] {
+    return SCENE_ORDER.map((id) => SCENE_MAP[id]);
+}
+
+export function getSceneDefinition(id: SceneId): SceneDefinition {
+    const entry = SCENE_MAP[id];
+    if (!entry) {
+        throw new Error(`Unknown scene id: ${id}`);
+    }
+    return entry;
+}
+
+export const SCENE_IDS = {
+    ...TRIANGLE_SCENE_IDS,
+};

--- a/src/ui/scenes/triangleScenes.ts
+++ b/src/ui/scenes/triangleScenes.ts
@@ -1,0 +1,35 @@
+import { GEOMETRY_KIND } from "@/geom/core/types";
+import type { SceneDefinition, SceneId } from "./types";
+
+export const TRIANGLE_SCENE_IDS = {
+    hyperbolic: "triangle:hyperbolic" as const,
+    euclidean: "triangle:euclidean" as const,
+};
+
+export const TRIANGLE_SCENES: Record<SceneId, SceneDefinition> = {
+    [TRIANGLE_SCENE_IDS.hyperbolic]: {
+        id: TRIANGLE_SCENE_IDS.hyperbolic,
+        label: "Hyperbolic Triangle",
+        category: "triangle",
+        geometry: GEOMETRY_KIND.hyperbolic,
+        description: "Generates a {p,q,r} hyperbolic tiling rendered inside the Poincaré disk.",
+        supportsHandles: false,
+        editable: false,
+    },
+    [TRIANGLE_SCENE_IDS.euclidean]: {
+        id: TRIANGLE_SCENE_IDS.euclidean,
+        label: "Euclidean Half-Planes",
+        category: "triangle",
+        geometry: GEOMETRY_KIND.euclidean,
+        description: "Interactive Euclidean mirrors derived from the current {p,q,r} triangle.",
+        supportsHandles: true,
+        editable: true,
+    },
+};
+
+export const TRIANGLE_SCENE_ORDER: SceneId[] = [
+    TRIANGLE_SCENE_IDS.hyperbolic,
+    TRIANGLE_SCENE_IDS.euclidean,
+];
+
+export const DEFAULT_TRIANGLE_SCENE_ID: SceneId = TRIANGLE_SCENE_IDS.hyperbolic;

--- a/src/ui/scenes/types.ts
+++ b/src/ui/scenes/types.ts
@@ -1,0 +1,20 @@
+import type { GeometryKind } from "@/geom/core/types";
+
+export type SceneCategory = "triangle";
+
+export type SceneId = "triangle:hyperbolic" | "triangle:euclidean";
+
+export interface SceneDefinition {
+    id: SceneId;
+    label: string;
+    category: SceneCategory;
+    geometry: GeometryKind;
+    description?: string;
+    supportsHandles: boolean;
+    editable: boolean;
+}
+
+export type SceneRegistry = {
+    byId: Record<SceneId, SceneDefinition>;
+    order: SceneId[];
+};

--- a/tests/unit/ui/components.test.tsx
+++ b/tests/unit/ui/components.test.tsx
@@ -1,7 +1,9 @@
 import { act, createRef } from "react";
 import { createRoot } from "react-dom/client";
 import { describe, expect, it, vi } from "vitest";
+import { GEOMETRY_KIND } from "@/geom/core/types";
 import type { PqrKey } from "@/geom/triangle/snap";
+import type { SceneDefinition, SceneId } from "@/ui/scenes";
 import { DepthControls } from "../../../src/ui/components/DepthControls";
 import { ModeControls } from "../../../src/ui/components/ModeControls";
 import { PresetSelector } from "../../../src/ui/components/PresetSelector";
@@ -69,15 +71,34 @@ describe("UI components", () => {
         });
     });
 
-    it("allows switching geometry modes", () => {
+    it("allows switching scenes", () => {
         const onChange = vi.fn();
+        const scenes: SceneDefinition[] = [
+            {
+                id: "triangle:hyperbolic",
+                label: "Hyperbolic",
+                category: "triangle",
+                geometry: GEOMETRY_KIND.hyperbolic,
+                supportsHandles: false,
+                editable: false,
+            },
+            {
+                id: "triangle:euclidean",
+                label: "Euclidean",
+                category: "triangle",
+                geometry: GEOMETRY_KIND.euclidean,
+                supportsHandles: true,
+                editable: true,
+            },
+        ];
         const container = document.createElement("div");
         const root = createRoot(container);
         act(() => {
             root.render(
                 <ModeControls
-                    geometryMode="hyperbolic"
-                    onGeometryChange={onChange}
+                    scenes={scenes}
+                    activeSceneId={"triangle:hyperbolic" satisfies SceneId}
+                    onSceneChange={onChange}
                     renderBackend="hybrid"
                 />,
             );
@@ -87,7 +108,7 @@ describe("UI components", () => {
         act(() => {
             buttons[1]?.click();
         });
-        expect(onChange).toHaveBeenCalledWith("euclidean");
+        expect(onChange).toHaveBeenCalledWith("triangle:euclidean");
         act(() => {
             root.unmount();
         });


### PR DESCRIPTION
Closes #106

## 目的（Why）
- 背景/課題: App コンポーネントが三角形パラメータUIと半平面編集ロジックを抱え込み、別シーン追加が難しい構造になっていた。
- 目標: シーン定義と SceneHost を導入し、Hyperbolic/Euclidean を切り替えられる土台を整備する。

## 変更点（What）
- SceneDefinition/SceneRegistry を追加し、既存の三角シーン情報を一元管理。
- TriangleSceneHost を実装して App を薄くし、シーン選択 UI を SceneId ベースに再構成。
- 既存ユニットテストを新しい ModeControls API に合わせて更新。

### 技術詳細（How）
- `src/ui/scenes/` 以下に SceneDefinition 型、レジストリ、三角シーンの初期データを作成。
- App は renderMode/sceneId を保持し、SceneHost（現状は TriangleSceneHost）のみを描画。
- 共有制御点ロジックや半平面編集ハンドラは TriangleSceneHost に移植して責務を限定。
- ModeControls は SceneDefinition の配列と SceneId を入力とする汎用 UI に変更。

## スクリーンショット / 動作デモ（任意）
- なし（ロジック整理のみ）

## 受け入れ条件（DoD）
- [x] 目的を満たすユーザーストーリーが確認できる
- [x] `pnpm lint` / `pnpm typecheck` / `pnpm test` が緑（coverage v8）
- [x] 重要分岐のユニット/プロパティテストが追加されている
- [ ] README/Docs/Storybook（該当時）が更新されている
- [x] アクセシビリティ: ラベル/フォーカス/キーボードが機能し重大違反なし

## 確認手順（Reviewer 向け）
```bash
pnpm i
pnpm lint && pnpm typecheck && pnpm test
```

## リスクとロールバック
- 影響範囲: UI/App 周辺、半平面編集。
- リスク/懸念: シーン切替時のステート引き継ぎに不備があると表示不整合が発生する可能性。
- ロールバック指針: このPRを revert して従来の App 構造に戻す。

## Out of Scope（別PR）
- ヒンジシーン等の新規シーン実装
- SceneDefinition の Storybook / Docs 整備

## 関連 Issue / PR
- Refs #104

## 追加メモ（任意）
- なし
