### PR TITLE
feat: add regular hexagon scene

### DIFF
--- a/src/render/canvasLayers.ts
+++ b/src/render/canvasLayers.ts
@@ -28,9 +28,7 @@ export type HalfPlaneHandleOverlay = {
     fixedSize?: number;
 };
 
-export type CanvasTileRenderOptions = CanvasTileStyle & {
-    handleOverlay?: HalfPlaneHandleOverlay;
-};
+export type CanvasTileRenderOptions = CanvasTileStyle;
 
 export function renderTileLayer(
     ctx: CanvasRenderingContext2D,
@@ -56,10 +54,6 @@ export function renderTileLayer(
 
     for (const plane of scene.halfPlanes) {
         drawHalfPlaneBoundary(ctx, plane, viewport, { strokeStyle: tileStroke, lineWidth });
-    }
-
-    if (options.handleOverlay?.visible) {
-        drawHalfPlaneHandles(ctx, viewport, options.handleOverlay);
     }
 }
 
@@ -99,7 +93,7 @@ function drawHalfPlaneBoundary(
     drawLine(ctx, { x1: a.x, y1: a.y, x2: b.x, y2: b.y }, style);
 }
 
-function drawHalfPlaneHandles(
+export function renderHandleOverlay(
     ctx: CanvasRenderingContext2D,
     viewport: Viewport,
     overlay: HalfPlaneHandleOverlay,

--- a/src/render/engine.ts
+++ b/src/render/engine.ts
@@ -75,10 +75,17 @@ export function createRenderEngine(
         setCanvasDPR(canvas);
         const rect = canvas.getBoundingClientRect();
         const viewport = computeViewport(rect, canvas);
-        const scene: RenderScene =
-            request.geometry === GEOMETRY_KIND.hyperbolic
-                ? buildHyperbolicScene(request.params, viewport)
-                : buildEuclideanScene(request.halfPlanes, viewport);
+        let scene: RenderScene;
+        try {
+            scene =
+                request.geometry === GEOMETRY_KIND.hyperbolic
+                    ? buildHyperbolicScene(request.params, viewport)
+                    : buildEuclideanScene(request.halfPlanes, viewport);
+        } catch (error) {
+            console.error("[RenderEngine] Failed to build scene", error);
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+            return;
+        }
         const hasWebGLOutput = Boolean(webgl?.ready && webgl.canvas);
         const canvasStyle: CanvasTileRenderOptions = {
             drawDisk: scene.geometry === GEOMETRY_KIND.hyperbolic,

--- a/src/render/engine.ts
+++ b/src/render/engine.ts
@@ -3,7 +3,12 @@ import type { HalfPlane } from "@/geom/primitives/halfPlane";
 import type { HalfPlaneControlPoints } from "@/geom/primitives/halfPlaneControls";
 import type { TilingParams } from "@/geom/triangle/tiling";
 import { attachResize, setCanvasDPR } from "./canvas";
-import { type CanvasTileRenderOptions, renderTileLayer } from "./canvasLayers";
+import {
+    type CanvasTileRenderOptions,
+    type HalfPlaneHandleOverlay,
+    renderHandleOverlay,
+    renderTileLayer,
+} from "./canvasLayers";
 import { buildEuclideanScene, buildHyperbolicScene, type RenderScene } from "./scene";
 import type { Viewport } from "./viewport";
 import { createWebGLRenderer, type WebGLInitResult } from "./webglRenderer";
@@ -78,6 +83,7 @@ export function createRenderEngine(
         const canvasStyle: CanvasTileRenderOptions = {
             drawDisk: scene.geometry === GEOMETRY_KIND.hyperbolic,
         };
+        let handleOverlay: HalfPlaneHandleOverlay | null = null;
         if (hasWebGLOutput) {
             canvasStyle.tileStroke = "rgba(0,0,0,0)";
         }
@@ -87,7 +93,7 @@ export function createRenderEngine(
         ) {
             const handles = request.handles;
             if (handles?.visible) {
-                canvasStyle.handleOverlay = {
+                handleOverlay = {
                     visible: true,
                     handles: handles.items,
                     active: handles.active ?? null,
@@ -107,6 +113,9 @@ export function createRenderEngine(
             } else {
                 webgl.renderer.render(scene, viewport, { clipToDisk });
             }
+        }
+        if (handleOverlay?.visible) {
+            renderHandleOverlay(ctx, viewport, handleOverlay);
         }
     };
 

--- a/src/ui/scenes/triangleScenes.ts
+++ b/src/ui/scenes/triangleScenes.ts
@@ -8,6 +8,7 @@ export const TRIANGLE_SCENE_IDS = {
     hinge: "triangle:hinge" as const,
     regularSquare: "triangle:regular-square" as const,
     regularPentagon: "triangle:regular-pentagon" as const,
+    regularHexagon: "triangle:regular-hexagon" as const,
 };
 
 const HINGE_HALF_PLANES = [
@@ -25,6 +26,12 @@ const REGULAR_PENTAGON_CONFIG = createRegularPolygonSceneConfig({
     sides: 5,
     radius: 0.7,
     initialAngle: Math.PI / 2,
+});
+
+const REGULAR_HEXAGON_CONFIG = createRegularPolygonSceneConfig({
+    sides: 6,
+    radius: 0.7,
+    initialAngle: Math.PI / 6,
 });
 
 function cloneHalfPlanes(planes: readonly { normal: { x: number; y: number }; offset: number }[]) {
@@ -114,6 +121,20 @@ export const TRIANGLE_SCENES: Record<SceneId, SceneDefinition> = {
         controlAssignments: [...REGULAR_PENTAGON_CONFIG.controlAssignments],
         initialControlPoints: cloneControlPointsList(REGULAR_PENTAGON_CONFIG.initialControlPoints),
     },
+    [TRIANGLE_SCENE_IDS.regularHexagon]: {
+        id: TRIANGLE_SCENE_IDS.regularHexagon,
+        label: "Regular Hexagon",
+        category: "triangle",
+        geometry: GEOMETRY_KIND.euclidean,
+        description: "Six half-planes form a regular hexagon with shared draggable vertices.",
+        supportsHandles: true,
+        editable: true,
+        allowPlaneDrag: false,
+        defaultHandleSpacing: REGULAR_HEXAGON_CONFIG.defaultHandleSpacing,
+        initialHalfPlanes: cloneHalfPlanes(REGULAR_HEXAGON_CONFIG.halfPlanes),
+        controlAssignments: [...REGULAR_HEXAGON_CONFIG.controlAssignments],
+        initialControlPoints: cloneControlPointsList(REGULAR_HEXAGON_CONFIG.initialControlPoints),
+    },
 };
 
 export const TRIANGLE_SCENE_ORDER: SceneId[] = [
@@ -122,6 +143,7 @@ export const TRIANGLE_SCENE_ORDER: SceneId[] = [
     TRIANGLE_SCENE_IDS.hinge,
     TRIANGLE_SCENE_IDS.regularSquare,
     TRIANGLE_SCENE_IDS.regularPentagon,
+    TRIANGLE_SCENE_IDS.regularHexagon,
 ];
 
 export const DEFAULT_TRIANGLE_SCENE_ID: SceneId = TRIANGLE_SCENE_IDS.hyperbolic;

--- a/src/ui/scenes/types.ts
+++ b/src/ui/scenes/types.ts
@@ -12,7 +12,8 @@ export type SceneId =
     | "triangle:euclidean"
     | "triangle:hinge"
     | "triangle:regular-square"
-    | "triangle:regular-pentagon";
+    | "triangle:regular-pentagon"
+    | "triangle:regular-hexagon";
 
 export interface SceneDefinition {
     id: SceneId;

--- a/src/ui/stories/RegularHexagonScene.stories.tsx
+++ b/src/ui/stories/RegularHexagonScene.stories.tsx
@@ -1,0 +1,176 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, userEvent, waitFor } from "@storybook/test";
+import { useMemo, useState } from "react";
+import { detectRenderMode } from "@/render/engine";
+import { type Viewport, worldToScreen } from "@/render/viewport";
+import { useTriangleParams } from "@/ui/hooks/useTriangleParams";
+import { SCENE_IDS, type SceneId } from "@/ui/scenes";
+import { TriangleSceneHost } from "@/ui/scenes/TriangleSceneHost";
+import { useSceneRegistry } from "@/ui/scenes/useSceneRegistry";
+import { REGULAR_POLYGON_COMPONENT_DOC, REGULAR_POLYGON_PLAY_DOC } from "./regularPolygonDocs";
+
+const TRIANGLE_N_MAX = 100;
+const INITIAL_PARAMS = { p: 2, q: 3, r: 7, depth: 2 } as const;
+const DEPTH_RANGE = { min: 0, max: 10 } as const;
+
+function computeViewport(canvas: HTMLCanvasElement): Viewport {
+    const rect = canvas.getBoundingClientRect();
+    const width = rect.width || canvas.width || 1;
+    const height = rect.height || canvas.height || 1;
+    const size = Math.min(width, height);
+    const margin = 8;
+    const scale = Math.max(1, size / 2 - margin);
+    return { scale, tx: width / 2, ty: height / 2 };
+}
+
+function RegularHexagonDemo(): JSX.Element {
+    const { triangleScenes } = useSceneRegistry();
+    const [sceneId, setSceneId] = useState<SceneId>(SCENE_IDS.regularHexagon);
+    const scene = useMemo(
+        () => triangleScenes.find((item) => item.id === sceneId) ?? triangleScenes[0],
+        [sceneId, triangleScenes],
+    );
+    const renderMode = useMemo(() => detectRenderMode(), []);
+    const triangleParams = useTriangleParams({
+        initialParams: INITIAL_PARAMS,
+        triangleNMax: TRIANGLE_N_MAX,
+        depthRange: DEPTH_RANGE,
+        initialGeometryMode: scene.geometry,
+    });
+
+    return (
+        <div style={{ height: "600px", width: "100%" }}>
+            <TriangleSceneHost
+                scene={scene}
+                scenes={triangleScenes}
+                activeSceneId={sceneId}
+                onSceneChange={setSceneId}
+                renderMode={renderMode}
+                triangle={triangleParams}
+            />
+        </div>
+    );
+}
+
+const meta: Meta<typeof RegularHexagonDemo> = {
+    title: "Scenes/Regular Hexagon",
+    component: RegularHexagonDemo,
+    tags: ["autodocs"],
+    parameters: {
+        layout: "fullscreen",
+        controls: {
+            hideNoControlsWarning: true,
+        },
+        docs: {
+            description: {
+                component: `${REGULAR_POLYGON_COMPONENT_DOC}\n\n正六角形シーンでは偶数頂点での共有制御点回転を検証できます。`,
+            },
+        },
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof RegularHexagonDemo>;
+
+export const Default: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: `${REGULAR_POLYGON_PLAY_DOC}\n六角形では複数頂点を順番にドラッグ→戻すシナリオを実行します。`,
+            },
+        },
+    },
+    play: async ({ canvasElement }) => {
+        const stage = canvasElement.querySelector("#stage") as HTMLCanvasElement | null;
+        if (!stage) {
+            throw new Error("Stage canvas not found");
+        }
+        const readout = canvasElement.querySelector('[data-testid="handle-coordinates"]');
+        await waitFor(() => {
+            expect(readout?.textContent).toBeTruthy();
+        });
+
+        const parsePoints = () => {
+            const raw = readout?.textContent ?? "";
+            return raw
+                ? (JSON.parse(raw) as Array<
+                      Array<{ x: number; y: number; id: string; fixed: boolean }>
+                  >)
+                : [];
+        };
+
+        await waitFor(() => {
+            expect(parsePoints().length).toBe(6);
+        });
+
+        const rect = stage.getBoundingClientRect();
+        const viewport = computeViewport(stage);
+        const vertexIndices = [0, 2, 4];
+
+        for (const vertexIndex of vertexIndices) {
+            const currentPoints = parsePoints();
+            const handle = currentPoints[vertexIndex]?.[0];
+            if (!handle) {
+                throw new Error(`Handle for vertex-${vertexIndex} not found`);
+            }
+
+            const startScreen = worldToScreen(viewport, handle);
+            const from = {
+                clientX: rect.left + startScreen.x,
+                clientY: rect.top + startScreen.y,
+            };
+            const targetWorld = {
+                x: handle.x + 0.06 * Math.cos(vertexIndex),
+                y: handle.y + 0.06 * Math.sin(vertexIndex + 1),
+            };
+            const targetScreen = worldToScreen(viewport, targetWorld);
+            const to = {
+                clientX: rect.left + targetScreen.x,
+                clientY: rect.top + targetScreen.y,
+            };
+
+            await userEvent.pointer([
+                { target: stage, coords: from, keys: "[MouseLeft>]" },
+                { coords: to },
+                { keys: "[/MouseLeft]" },
+            ]);
+
+            await waitFor(() => {
+                const moved = parsePoints();
+                const movedHandle = moved[vertexIndex]?.[0];
+                expect(movedHandle).toBeTruthy();
+                if (!movedHandle) return;
+                const dx = movedHandle.x - handle.x;
+                const dy = movedHandle.y - handle.y;
+                expect(Math.hypot(dx, dy)).toBeGreaterThan(1e-3);
+            });
+
+            const movedPoints = parsePoints();
+            const movedHandle = movedPoints[vertexIndex]?.[0];
+            if (!movedHandle) {
+                throw new Error(`Moved handle for vertex-${vertexIndex} not found`);
+            }
+            const movedScreen = worldToScreen(viewport, movedHandle);
+            const movedCoords = {
+                clientX: rect.left + movedScreen.x,
+                clientY: rect.top + movedScreen.y,
+            };
+
+            await userEvent.pointer([
+                { target: stage, coords: movedCoords, keys: "[MouseLeft>]" },
+                { coords: from },
+                { keys: "[/MouseLeft]" },
+            ]);
+
+            await waitFor(() => {
+                const finalPoints = parsePoints();
+                const restored = finalPoints[vertexIndex]?.[0];
+                expect(restored).toBeTruthy();
+                if (!restored) return;
+                expect(restored.x).toBeCloseTo(handle.x, 3);
+                expect(restored.y).toBeCloseTo(handle.y, 3);
+            });
+        }
+    },
+};

--- a/src/ui/stories/RegularPentagonScene.stories.tsx
+++ b/src/ui/stories/RegularPentagonScene.stories.tsx
@@ -7,6 +7,7 @@ import { useTriangleParams } from "@/ui/hooks/useTriangleParams";
 import { SCENE_IDS, type SceneId } from "@/ui/scenes";
 import { TriangleSceneHost } from "@/ui/scenes/TriangleSceneHost";
 import { useSceneRegistry } from "@/ui/scenes/useSceneRegistry";
+import { REGULAR_POLYGON_COMPONENT_DOC, REGULAR_POLYGON_PLAY_DOC } from "./regularPolygonDocs";
 
 const TRIANGLE_N_MAX = 100;
 const INITIAL_PARAMS = { p: 2, q: 3, r: 7, depth: 2 } as const;
@@ -62,8 +63,7 @@ const meta: Meta<typeof RegularPentagonDemo> = {
         },
         docs: {
             description: {
-                component:
-                    "正五角形の半平面シーン。5つの共有頂点をドラッグして一般五角形へ変形できます。",
+                component: `${REGULAR_POLYGON_COMPONENT_DOC}\n\n正五角形シーンでは奇数頂点での共有制御点挙動を検証できます。`,
             },
         },
     },
@@ -77,7 +77,7 @@ export const Default: Story = {
     parameters: {
         docs: {
             description: {
-                story: "Play テストでは任意の頂点をドラッグし、変形後に初期位置へ戻せることを検証します。",
+                story: `${REGULAR_POLYGON_PLAY_DOC}\n五角形では単一頂点の往復操作を対象とします。`,
             },
         },
     },

--- a/src/ui/stories/regularPolygonDocs.ts
+++ b/src/ui/stories/regularPolygonDocs.ts
@@ -1,0 +1,11 @@
+export const REGULAR_POLYGON_COMPONENT_DOC = `
+正多角形シーン（Regular Square / Regular Pentagon / Regular Hexagon）は共通の操作モデルを持ちます。
+
+- 全ての頂点は共有制御点として扱われ、同じ ID の頂点をドラッグすると隣接 2 枚の半平面のみが更新されます。
+- 半平面そのものをドラッグする操作（plane drag）は無効化されており、各シーンは頂点ハンドルのみで編集します。
+- ハンドルは統一した色とサイズで描画され、固定扱いの頂点（例: ヒンジ）が存在しない限り全てドラッグ可能です。
+- Storybook Play ではハンドル座標を JSON テレメトリとして公開し、自動化シナリオで座標変化を検証できます。
+`;
+
+export const REGULAR_POLYGON_PLAY_DOC =
+    "Play テストでは複数の頂点をドラッグして戻す操作を自動化し、共有制御点の整合性を検証します。";

--- a/tests/unit/render/engine.test.ts
+++ b/tests/unit/render/engine.test.ts
@@ -86,4 +86,17 @@ describe("createRenderEngine", () => {
         expect(ctx.clearRect).toHaveBeenCalled();
         engine.dispose();
     });
+
+    it("guards against invalid hyperbolic parameters", () => {
+        const { canvas, ctx } = createMockCanvas();
+        const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+        const engine = createRenderEngine(canvas, { mode: "canvas" });
+        expect(() =>
+            engine.render({ geometry: "hyperbolic", params: { p: 3, q: 3, r: 3, depth: 1 } }),
+        ).not.toThrow();
+        expect(errorSpy).toHaveBeenCalled();
+        expect(ctx.clearRect).toHaveBeenCalled();
+        engine.dispose();
+        errorSpy.mockRestore();
+    });
 });

--- a/tests/unit/render/handleOverlay.test.ts
+++ b/tests/unit/render/handleOverlay.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { GEOMETRY_KIND } from "@/geom/core/types";
-import { renderTileLayer } from "@/render/canvasLayers";
+import { renderHandleOverlay, renderTileLayer } from "@/render/canvasLayers";
 
 function createMockContext(): CanvasRenderingContext2D {
     const canvas = document.createElement("canvas");
@@ -32,19 +32,21 @@ describe("renderTileLayer handle overlay", () => {
             ctx,
             { geometry: GEOMETRY_KIND.euclidean, halfPlanes: [] },
             { scale: 100, tx: 0, ty: 0 },
+        );
+        renderHandleOverlay(
+            ctx,
+            { scale: 100, tx: 0, ty: 0 },
             {
-                handleOverlay: {
-                    visible: true,
-                    handles: [
-                        {
-                            planeIndex: 0,
-                            points: [
-                                { id: "hinge", x: 0, y: 0, fixed: true },
-                                { id: "free", x: 1, y: 0, fixed: false },
-                            ],
-                        },
-                    ],
-                },
+                visible: true,
+                handles: [
+                    {
+                        planeIndex: 0,
+                        points: [
+                            { id: "hinge", x: 0, y: 0, fixed: true },
+                            { id: "free", x: 1, y: 0, fixed: false },
+                        ],
+                    },
+                ],
             },
         );
         expect(ctx.fillRect).toHaveBeenCalled();


### PR DESCRIPTION
Closes #111

## 目的（Why）
- 背景/課題: 正多角形シーンのバリエーションが 4/5 頂点に留まり、連続ドラッグの挙動や共通ルールが可視化しづらかった。
- 目標: 正六角形シーンと共通Docs/Playテストを整備し、共有制御点挙動を体系的に検証・説明できる状態にする。

## 変更点（What）
- 正六角形シーンをSceneRegistryに追加し、正多角形群のセレクタを拡張。
- 奇数/偶数頂点双方で共有制御点の連続ドラッグが隣接半平面のみを更新することをユニットテストで保証。
- 正多角形シーン共通Docsを整理し、Storybookに正六角形ストーリーと複数頂点のPlayテストを追加。
- レンダラーで制御点ハンドルを常に最前面に描画し、無効なハイパーボリックパラメータへのガードを実装。

### 技術詳細（How）
- `createRegularPolygonSceneConfig` を再利用し、6頂点用初期角を π/6 に設定して正六角形データを生成。
- `updateControlPoint` の共有ID伝播を活かし、連続ドラッグ検証をユニットテストでループ化。
- Storybook Playは`handle-coordinates`テレメトリを利用し、三頂点（0/2/4）を順番にドラッグ→復帰するシナリオを自動化。
- Canvasレンダリングとハイブリッド描画双方で、半平面描画後にオーバーレイを別途描画するようリファクタ。
- ハイパーボリック描画では Scene 構築例外を捕捉し、canvas clear + console.errorに倒すフェイルセーフを追加。

## スクリーンショット / 動作デモ（任意）
- Storybook: `Scenes/Regular Hexagon`

## 受け入れ条件（DoD）
- [x] 目的を満たすユーザーストーリーが確認できる
- [x] `pnpm lint` / `pnpm typecheck` / `pnpm test` が緑（coverage v8）
- [x] 重要分岐のユニット/プロパティテストが追加されている
- [x] README/Docs/Storybook（該当時）が更新されている
- [ ] アクセシビリティ: ラベル/フォーカス/キーボードが機能し重大違反なし（既存UIに変更なしのため未チェック）

## 確認手順（Reviewer 向け）
```bash
pnpm i
pnpm lint
pnpm test
pnpm storybook
# Storybook の Scenes/Regular Hexagon で Play を確認
```

## リスクとロールバック
- 影響範囲: 正多角形シーン選択、レンダリングオーバーレイ、ハイパーボリック再描画
- リスク/懸念: レンダリング例外のサプレッションで根本原因を見逃す可能性（エラーログを残す設計）
- ロールバック指針: `feat/111-regular-hexagon-scene` を revert し、SceneRegistry/Story追加を除去

## Out of Scope（別PR）
- 7 頂点以上のシーン追加
- ハンドルの視認性改善（色やサイズの細分化）

## 関連 Issue / PR
- なし

## 追加メモ（任意）
- リリースノート案: 正六角形シーンと共通ドキュメントを追加し、共有頂点の連続ドラッグ動作を検証しやすくしました。
