### PR TITLE
feat: add circle inversion scene

### DIFF
--- a/docs/history/2025-10-06-euclidean-fill.md
+++ b/docs/history/2025-10-06-euclidean-fill.md
@@ -11,3 +11,7 @@
 4. 撮影した画像を `docs/history/2025-10-06-euclidean-fill.png` として保存し、今後の検証資料として共有します。
 
 > スクリーンショットは手動収集のためリポジトリには同梱していません。必要に応じて上記手順で再取得してください。
+
+## Circle Inversion シーン
+- `Scenes/Circle Inversion` では固定円と矩形の反転像をシェーダーで描画します。
+- Storybook Play では `data-testid="circle-inversion-state"` を参照して初期状態の半径・矩形サイズを検証できます。

--- a/src/render/engine.ts
+++ b/src/render/engine.ts
@@ -2,6 +2,7 @@ import { GEOMETRY_KIND } from "@/geom/core/types";
 import type { HalfPlane } from "@/geom/primitives/halfPlane";
 import type { HalfPlaneControlPoints } from "@/geom/primitives/halfPlaneControls";
 import type { TilingParams } from "@/geom/triangle/tiling";
+import type { CircleInversionState } from "@/ui/scenes/circleInversionConfig";
 import type { SceneDefinition } from "@/ui/scenes/types";
 import { attachResize, setCanvasDPR } from "./canvas";
 import {
@@ -35,6 +36,7 @@ export type GeometryRenderRequest =
           geometry: typeof GEOMETRY_KIND.euclidean;
           halfPlanes: HalfPlane[];
           handles?: HalfPlaneHandleRequest;
+          inversion?: CircleInversionState;
       } & RenderRequestBase);
 
 export interface RenderEngine {
@@ -110,6 +112,7 @@ export function createRenderEngine(
                     ? buildHyperbolicScene(request.params, viewport, { textures: sceneTextures })
                     : buildEuclideanScene(request.halfPlanes, viewport, {
                           textures: sceneTextures,
+                          inversion: request.inversion,
                       });
         } catch (error) {
             console.error("[RenderEngine] Failed to build scene", error);

--- a/src/render/scene.ts
+++ b/src/render/scene.ts
@@ -6,6 +6,7 @@ import type { SphericalSceneState } from "@/geom/spherical/types";
 import type { TriangleFace } from "@/geom/triangle/group";
 import type { TilingParams } from "@/geom/triangle/tiling";
 import { buildTiling } from "@/geom/triangle/tiling";
+import type { CircleInversionState } from "@/ui/scenes/circleInversionConfig";
 import { type CircleSpec, geodesicSpec, type LineSpec, unitDiskSpec } from "./primitives";
 import type { SphericalOrbitCamera } from "./spherical/camera";
 import type { SphericalRenderSettings } from "./spherical/renderer";
@@ -38,6 +39,7 @@ export type HyperbolicScene = SceneBase & {
 export type EuclideanScene = SceneBase & {
     geometry: typeof GEOMETRY_KIND.euclidean;
     halfPlanes: HalfPlane[];
+    inversion?: CircleInversionState;
 };
 
 export type SphericalScene = SceneBase & {
@@ -84,11 +86,12 @@ export function buildHyperbolicScene(
 export function buildEuclideanScene(
     planes: HalfPlane[],
     _vp: Viewport,
-    options: { textures?: SceneTextureLayer[] } = {},
+    options: { textures?: SceneTextureLayer[]; inversion?: CircleInversionState } = {},
 ): EuclideanScene {
     return {
         geometry: GEOMETRY_KIND.euclidean,
         halfPlanes: planes.map((plane) => normalizeHalfPlane(plane)),
         textures: options.textures ?? [],
+        inversion: options.inversion,
     };
 }

--- a/src/render/webgl/pipelines/euclideanCircleInversionPipeline.ts
+++ b/src/render/webgl/pipelines/euclideanCircleInversionPipeline.ts
@@ -1,0 +1,244 @@
+import { GEOMETRY_KIND } from "@/geom/core/types";
+import { SCENE_IDS } from "@/ui/scenes";
+import type { CircleInversionState } from "@/ui/scenes/circleInversionConfig";
+import {
+    registerSceneWebGLPipeline,
+    type WebGLPipelineInstance,
+    type WebGLPipelineRenderContext,
+} from "../pipelineRegistry";
+import fragmentShaderSource from "../shaders/euclideanCircleInversion.frag?raw";
+import vertexShaderSource from "../shaders/geodesic.vert?raw";
+
+export const EUCLIDEAN_CIRCLE_INVERSION_PIPELINE_ID = "webgl-euclidean-circle-inversion" as const;
+
+const RECT_COLOR = [0.231, 0.514, 0.918, 0.75] as const;
+const INVERTED_COLOR = [0.976, 0.545, 0.259, 0.72] as const;
+const CIRCLE_COLOR = [0.95, 0.98, 1.0, 0.9] as const;
+
+const RECT_FEATHER_PX = 1.5;
+const CIRCLE_STROKE_WIDTH_PX = 2.0;
+const CIRCLE_FEATHER_PX = 1.2;
+
+class EuclideanCircleInversionPipeline implements WebGLPipelineInstance {
+    private readonly gl: WebGL2RenderingContext;
+    private readonly program: WebGLProgram;
+    private readonly vao: WebGLVertexArrayObject;
+    private readonly vertexBuffer: WebGLBuffer;
+    private readonly uniforms: UniformLocations;
+
+    constructor(gl: WebGL2RenderingContext) {
+        this.gl = gl;
+        const vertex = compileShader(gl, gl.VERTEX_SHADER, vertexShaderSource);
+        const fragment = compileShader(gl, gl.FRAGMENT_SHADER, fragmentShaderSource);
+        this.program = linkProgram(gl, vertex, fragment);
+        gl.deleteShader(vertex);
+        gl.deleteShader(fragment);
+
+        const vao = gl.createVertexArray();
+        if (!vao) throw new Error("Failed to create VAO");
+        this.vao = vao;
+        const vertexBuffer = gl.createBuffer();
+        if (!vertexBuffer) throw new Error("Failed to create vertex buffer");
+        this.vertexBuffer = vertexBuffer;
+
+        const fullscreenTriangle = new Float32Array([-1, -1, 3, -1, -1, 3]);
+
+        gl.bindVertexArray(this.vao);
+        gl.bindBuffer(gl.ARRAY_BUFFER, this.vertexBuffer);
+        gl.bufferData(gl.ARRAY_BUFFER, fullscreenTriangle, gl.STATIC_DRAW);
+        gl.enableVertexAttribArray(0);
+        gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+        gl.bindVertexArray(null);
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+
+        gl.disable(gl.DEPTH_TEST);
+        gl.enable(gl.BLEND);
+        gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+
+        this.uniforms = resolveUniformLocations(gl, this.program);
+
+        // biome-ignore lint/correctness/useHookAtTopLevel: WebGL API invocation outside React components.
+        gl.useProgram(this.program);
+        gl.uniform4f(this.uniforms.rectColor, ...RECT_COLOR);
+        gl.uniform4f(this.uniforms.invertedColor, ...INVERTED_COLOR);
+        gl.uniform4f(this.uniforms.circleColor, ...CIRCLE_COLOR);
+        gl.uniform1f(this.uniforms.rectFeatherPx, RECT_FEATHER_PX);
+        gl.uniform1f(this.uniforms.circleStrokeWidthPx, CIRCLE_STROKE_WIDTH_PX);
+        gl.uniform1f(this.uniforms.circleFeatherPx, CIRCLE_FEATHER_PX);
+        // biome-ignore lint/correctness/useHookAtTopLevel: WebGL API invocation outside React components.
+        gl.useProgram(null);
+    }
+
+    render({ sceneDefinition, renderScene, viewport, canvas }: WebGLPipelineRenderContext): void {
+        if (renderScene.geometry !== GEOMETRY_KIND.euclidean) {
+            return;
+        }
+        const gl = this.gl;
+        const width = canvas.width || gl.drawingBufferWidth || 1;
+        const height = canvas.height || gl.drawingBufferHeight || 1;
+
+        const resolvedState = resolveInversionState(sceneDefinition?.inversionConfig, renderScene);
+        if (!resolvedState) {
+            gl.clearColor(0, 0, 0, 0);
+            gl.clear(gl.COLOR_BUFFER_BIT);
+            return;
+        }
+
+        gl.viewport(0, 0, width, height);
+        // biome-ignore lint/correctness/useHookAtTopLevel: WebGL API invocation outside React components.
+        gl.useProgram(this.program);
+        gl.uniform2f(this.uniforms.resolution, width, height);
+        gl.uniform3f(this.uniforms.viewport, viewport.scale, viewport.tx, viewport.ty);
+        gl.uniform2f(
+            this.uniforms.circleCenter,
+            resolvedState.fixedCircle.center.x,
+            resolvedState.fixedCircle.center.y,
+        );
+        gl.uniform1f(this.uniforms.circleRadius, resolvedState.fixedCircle.radius);
+        gl.uniform2f(
+            this.uniforms.rectCenter,
+            resolvedState.rectangle.center.x,
+            resolvedState.rectangle.center.y,
+        );
+        gl.uniform2f(
+            this.uniforms.rectHalfExtents,
+            resolvedState.rectangle.halfExtents.x,
+            resolvedState.rectangle.halfExtents.y,
+        );
+        gl.uniform1f(this.uniforms.rectRotation, resolvedState.rectangle.rotation);
+
+        gl.clearColor(0, 0, 0, 0);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+        gl.bindVertexArray(this.vao);
+        gl.drawArrays(gl.TRIANGLES, 0, 3);
+        gl.bindVertexArray(null);
+        // biome-ignore lint/correctness/useHookAtTopLevel: WebGL API invocation outside React components.
+        gl.useProgram(null);
+    }
+
+    dispose(): void {
+        const gl = this.gl;
+        gl.deleteBuffer(this.vertexBuffer);
+        gl.deleteVertexArray(this.vao);
+        gl.deleteProgram(this.program);
+    }
+}
+
+type UniformLocations = {
+    resolution: WebGLUniformLocation;
+    viewport: WebGLUniformLocation;
+    circleCenter: WebGLUniformLocation;
+    circleRadius: WebGLUniformLocation;
+    rectCenter: WebGLUniformLocation;
+    rectHalfExtents: WebGLUniformLocation;
+    rectRotation: WebGLUniformLocation;
+    rectColor: WebGLUniformLocation;
+    invertedColor: WebGLUniformLocation;
+    circleColor: WebGLUniformLocation;
+    rectFeatherPx: WebGLUniformLocation;
+    circleStrokeWidthPx: WebGLUniformLocation;
+    circleFeatherPx: WebGLUniformLocation;
+};
+
+function resolveInversionState(
+    config: CircleInversionState | undefined,
+    scene: WebGLPipelineRenderContext["renderScene"],
+): CircleInversionState | null {
+    if (scene.geometry !== GEOMETRY_KIND.euclidean) {
+        return null;
+    }
+    const runtimeState = scene.inversion;
+    if (runtimeState) {
+        return {
+            fixedCircle: {
+                center: { ...runtimeState.fixedCircle.center },
+                radius: runtimeState.fixedCircle.radius,
+            },
+            rectangle: {
+                center: { ...runtimeState.rectangle.center },
+                halfExtents: { ...runtimeState.rectangle.halfExtents },
+                rotation: runtimeState.rectangle.rotation,
+            },
+        };
+    }
+    if (config) {
+        return {
+            fixedCircle: {
+                center: { ...config.fixedCircle.center },
+                radius: config.fixedCircle.radius,
+            },
+            rectangle: {
+                center: { ...config.rectangle.center },
+                halfExtents: { ...config.rectangle.halfExtents },
+                rotation: config.rectangle.rotation,
+            },
+        };
+    }
+    return null;
+}
+
+function compileShader(gl: WebGL2RenderingContext, type: number, source: string): WebGLShader {
+    const shader = gl.createShader(type);
+    if (!shader) throw new Error("Failed to create shader");
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+        const info = gl.getShaderInfoLog(shader) ?? "Unknown error";
+        gl.deleteShader(shader);
+        throw new Error(`Shader compilation failed: ${info}`);
+    }
+    return shader;
+}
+
+function linkProgram(
+    gl: WebGL2RenderingContext,
+    vertex: WebGLShader,
+    fragment: WebGLShader,
+): WebGLProgram {
+    const program = gl.createProgram();
+    if (!program) throw new Error("Failed to create program");
+    gl.attachShader(program, vertex);
+    gl.attachShader(program, fragment);
+    gl.linkProgram(program);
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+        const info = gl.getProgramInfoLog(program) ?? "Unknown error";
+        gl.deleteProgram(program);
+        throw new Error(`Program link failed: ${info}`);
+    }
+    return program;
+}
+
+function getUniformLocation(gl: WebGL2RenderingContext, program: WebGLProgram, name: string) {
+    const location = gl.getUniformLocation(program, name);
+    if (!location) {
+        throw new Error(`Uniform not found: ${name}`);
+    }
+    return location;
+}
+
+function resolveUniformLocations(
+    gl: WebGL2RenderingContext,
+    program: WebGLProgram,
+): UniformLocations {
+    return {
+        resolution: getUniformLocation(gl, program, "uResolution"),
+        viewport: getUniformLocation(gl, program, "uViewport"),
+        circleCenter: getUniformLocation(gl, program, "uCircleCenter"),
+        circleRadius: getUniformLocation(gl, program, "uCircleRadius"),
+        rectCenter: getUniformLocation(gl, program, "uRectCenter"),
+        rectHalfExtents: getUniformLocation(gl, program, "uRectHalfExtents"),
+        rectRotation: getUniformLocation(gl, program, "uRectRotation"),
+        rectColor: getUniformLocation(gl, program, "uRectColor"),
+        invertedColor: getUniformLocation(gl, program, "uInvertedColor"),
+        circleColor: getUniformLocation(gl, program, "uCircleColor"),
+        rectFeatherPx: getUniformLocation(gl, program, "uRectFeatherPx"),
+        circleStrokeWidthPx: getUniformLocation(gl, program, "uCircleStrokeWidthPx"),
+        circleFeatherPx: getUniformLocation(gl, program, "uCircleFeatherPx"),
+    };
+}
+
+registerSceneWebGLPipeline(
+    SCENE_IDS.euclideanCircleInversion,
+    EUCLIDEAN_CIRCLE_INVERSION_PIPELINE_ID,
+    (gl) => new EuclideanCircleInversionPipeline(gl),
+);

--- a/src/render/webgl/shaders/euclideanCircleInversion.frag
+++ b/src/render/webgl/shaders/euclideanCircleInversion.frag
@@ -1,0 +1,96 @@
+#version 300 es
+precision highp float;
+
+in vec2 vFragCoord;
+layout(location = 0) out vec4 outColor;
+
+uniform vec3 uViewport; // (scale, tx, ty)
+uniform vec2 uCircleCenter;
+uniform float uCircleRadius;
+uniform vec2 uRectCenter;
+uniform vec2 uRectHalfExtents;
+uniform float uRectRotation;
+uniform vec4 uRectColor;
+uniform vec4 uInvertedColor;
+uniform vec4 uCircleColor;
+uniform float uRectFeatherPx;
+uniform float uCircleStrokeWidthPx;
+uniform float uCircleFeatherPx;
+
+vec2 screenToWorld(vec2 fragCoord) {
+    float scale = max(uViewport.x, 1e-6);
+    vec2 translation = uViewport.yz;
+    return (fragCoord - translation) / scale;
+}
+
+mat2 rotationMatrix(float angle) {
+    float c = cos(angle);
+    float s = sin(angle);
+    return mat2(c, -s, s, c);
+}
+
+float rectangleSDF(vec2 point) {
+    vec2 local = rotationMatrix(-uRectRotation) * (point - uRectCenter);
+    vec2 d = abs(local) - uRectHalfExtents;
+    vec2 outside = max(d, 0.0);
+    float outsideDist = length(outside);
+    float insideDist = min(max(d.x, d.y), 0.0);
+    return outsideDist + insideDist;
+}
+
+vec2 invertPoint(vec2 point) {
+    vec2 diff = point - uCircleCenter;
+    float distSq = dot(diff, diff);
+    float radiusSq = uCircleRadius * uCircleRadius;
+    if (distSq <= 1e-8) {
+        return uCircleCenter + vec2(radiusSq, 0.0);
+    }
+    return uCircleCenter + (radiusSq / distSq) * diff;
+}
+
+float smoothFill(float sdfPx, float featherPx) {
+    return 1.0 - smoothstep(0.0, featherPx, sdfPx);
+}
+
+void main() {
+    vec2 worldPoint = screenToWorld(vFragCoord);
+    float scale = max(uViewport.x, 1e-6);
+
+    float rectSdfPx = rectangleSDF(worldPoint) * scale;
+    float rectFill = smoothFill(rectSdfPx, uRectFeatherPx);
+
+    vec2 invertedPoint = invertPoint(worldPoint);
+    float invertedSdfPx = rectangleSDF(invertedPoint) * scale;
+    float invertedFill = smoothFill(invertedSdfPx, uRectFeatherPx);
+
+    float circlePxDistance = abs(length(worldPoint - uCircleCenter) - uCircleRadius) * scale;
+    float circleStroke = 1.0 - smoothstep(
+        max(uCircleStrokeWidthPx - uCircleFeatherPx, 0.0),
+        uCircleStrokeWidthPx + uCircleFeatherPx,
+        circlePxDistance
+    );
+
+    vec4 color = vec4(0.0);
+    if (rectFill > 0.0) {
+        float alpha = rectFill * uRectColor.a;
+        color.rgb = mix(color.rgb, uRectColor.rgb, alpha);
+        color.a = max(color.a, alpha);
+    }
+
+    if (invertedFill > 0.0) {
+        float alpha = invertedFill * uInvertedColor.a;
+        color.rgb = mix(color.rgb, uInvertedColor.rgb, alpha);
+        color.a = max(color.a, alpha);
+    }
+
+    if (circleStroke > 0.0) {
+        float alpha = circleStroke * uCircleColor.a;
+        color.rgb = mix(color.rgb, uCircleColor.rgb, alpha);
+        color.a = max(color.a, alpha);
+    }
+
+    if (color.a <= 1e-4) {
+        discard;
+    }
+    outColor = vec4(color.rgb, color.a);
+}

--- a/src/render/webglRenderer.ts
+++ b/src/render/webglRenderer.ts
@@ -9,6 +9,7 @@ import {
 import type { TextureLayer } from "./webgl/textures";
 import "./webgl/pipelines/hyperbolicGeodesicPipeline";
 import "./webgl/pipelines/euclideanHalfPlanePipeline";
+import "./webgl/pipelines/euclideanCircleInversionPipeline";
 import "./webgl/pipelines/sphericalPipeline";
 import "./webgl/pipelines/debugTexturePipeline";
 

--- a/src/ui/scenes/circleInversionConfig.ts
+++ b/src/ui/scenes/circleInversionConfig.ts
@@ -1,0 +1,15 @@
+import type { Vec2 } from "@/geom/core/types";
+
+export interface CircleInversionState {
+    fixedCircle: {
+        center: Vec2;
+        radius: number;
+    };
+    rectangle: {
+        center: Vec2;
+        halfExtents: Vec2;
+        rotation: number;
+    };
+}
+
+export type CircleInversionSceneConfig = CircleInversionState;

--- a/src/ui/scenes/sceneDefinitions.ts
+++ b/src/ui/scenes/sceneDefinitions.ts
@@ -83,6 +83,7 @@ type SceneAlias =
     | "euclideanSingleHalfPlane"
     | "euclideanHalfPlanes"
     | "euclideanHinge"
+    | "euclideanCircleInversion"
     | "euclideanRegularSquare"
     | "euclideanRegularPentagon"
     | "euclideanRegularHexagon"
@@ -152,6 +153,27 @@ const BASE_SCENE_INPUTS: SceneDefinitionEntry[] = [
             { planeIndex: 1, pointIndex: 1, id: "hinge", fixed: true },
         ],
         initialControlPoints: cloneControlPointsList(HINGE_INITIAL_CONTROL_POINTS),
+    },
+    {
+        key: "euclideanCircleInversion",
+        label: "Circle Inversion",
+        geometry: GEOMETRY_KIND.euclidean,
+        variant: "circle-inversion",
+        description:
+            "Inverts a draggable rectangle across a fixed circle using the WebGL pipeline.",
+        supportsHandles: false,
+        editable: true,
+        inversionConfig: {
+            fixedCircle: {
+                center: { x: 0, y: 0 },
+                radius: 0.6,
+            },
+            rectangle: {
+                center: { x: 0.3, y: 0 },
+                halfExtents: { x: 0.15, y: 0.1 },
+                rotation: 0,
+            },
+        },
     },
     {
         key: "euclideanRegularSquare",

--- a/src/ui/scenes/types.ts
+++ b/src/ui/scenes/types.ts
@@ -5,6 +5,7 @@ import type {
     HalfPlaneControlPoints,
 } from "@/geom/primitives/halfPlaneControls";
 import type { SphericalSceneState } from "@/geom/spherical/types";
+import type { CircleInversionSceneConfig } from "./circleInversionConfig";
 
 export type SceneVariant = string;
 
@@ -30,6 +31,7 @@ export interface SceneDefinition {
     initialControlPoints?: HalfPlaneControlPoints[];
     defaultHandleSpacing?: number;
     initialSphericalState?: SphericalSceneState;
+    inversionConfig?: CircleInversionSceneConfig;
 }
 
 export type SceneDefinitionInput = Omit<SceneDefinition, "id">;

--- a/src/ui/stories/CircleInversionScene.stories.tsx
+++ b/src/ui/stories/CircleInversionScene.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, waitFor } from "@storybook/test";
+import { useMemo } from "react";
+import { detectRenderMode } from "@/render/engine";
+import { useTriangleParams } from "@/ui/hooks/useTriangleParams";
+import { SCENE_IDS } from "@/ui/scenes";
+import { EuclideanSceneHost } from "@/ui/scenes/EuclideanSceneHost";
+import { useSceneRegistry } from "@/ui/scenes/useSceneRegistry";
+
+const TRIANGLE_N_MAX = 100;
+const INITIAL_PARAMS = { p: 2, q: 3, r: 7, depth: 2 } as const;
+const DEPTH_RANGE = { min: 0, max: 10 } as const;
+
+function CircleInversionSceneDemo(): JSX.Element {
+    const { scenes } = useSceneRegistry();
+    const scene = useMemo(() => {
+        const match = scenes.find((item) => item.id === SCENE_IDS.euclideanCircleInversion);
+        if (!match) {
+            throw new Error("Circle inversion scene definition not registered");
+        }
+        return match;
+    }, [scenes]);
+
+    const renderMode = useMemo(() => detectRenderMode(), []);
+    const triangleParams = useTriangleParams({
+        initialParams: INITIAL_PARAMS,
+        triangleNMax: TRIANGLE_N_MAX,
+        depthRange: DEPTH_RANGE,
+        initialGeometryMode: scene.geometry,
+    });
+
+    return (
+        <section style={{ height: "520px", width: "100%" }} aria-label="circle-inversion-demo">
+            <EuclideanSceneHost
+                scene={scene}
+                scenes={[scene]}
+                activeSceneId={scene.id}
+                onSceneChange={() => {
+                    /* single scene showcase */
+                }}
+                renderMode={renderMode}
+                triangle={triangleParams}
+            />
+        </section>
+    );
+}
+
+const meta: Meta<typeof CircleInversionSceneDemo> = {
+    title: "Scenes/Circle Inversion",
+    component: CircleInversionSceneDemo,
+    tags: ["autodocs"],
+    parameters: {
+        layout: "fullscreen",
+        docs: {
+            description: {
+                component:
+                    "固定円に対する図形の反転を WebGL シェーダーで描画するシーンです。矩形をドラッグして反転像との対応を確認できます。",
+            },
+        },
+        accessibility: {
+            element: "[aria-label=circle-inversion-demo]",
+        },
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof CircleInversionSceneDemo>;
+
+export const Default: Story = {
+    play: async ({ canvasElement }) => {
+        const readout = canvasElement.querySelector(
+            '[data-testid="circle-inversion-state"]',
+        ) as HTMLSpanElement | null;
+        await waitFor(() => {
+            expect(readout?.textContent).toBeTruthy();
+        });
+        const parsed = JSON.parse(readout?.textContent ?? "{}");
+        expect(parsed.fixedCircle.radius).toBeGreaterThan(0);
+        expect(parsed.rectangle.halfExtents.x).toBeGreaterThan(0);
+        expect(parsed.rectangle.halfExtents.y).toBeGreaterThan(0);
+    },
+};

--- a/tests/unit/render/scene.test.ts
+++ b/tests/unit/render/scene.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { HalfPlane } from "@/geom/primitives/halfPlane";
 import { buildEuclideanScene, buildHyperbolicScene } from "@/render/scene";
 import type { Viewport } from "@/render/viewport";
+import type { CircleInversionState } from "@/ui/scenes/circleInversionConfig";
 
 const VIEWPORT: Viewport = { scale: 100, tx: 120, ty: 120 };
 const PLANES: HalfPlane[] = [
@@ -27,5 +28,18 @@ describe("buildEuclideanScene", () => {
         expect(scene.halfPlanes.length).toBe(PLANES.length);
         expect((scene as unknown as { disk?: unknown }).disk).toBeUndefined();
         expect(scene.textures).toEqual([]);
+    });
+
+    it("includes inversion data when provided", () => {
+        const inversion: CircleInversionState = {
+            fixedCircle: { center: { x: 0, y: 0 }, radius: 0.5 },
+            rectangle: {
+                center: { x: 0.25, y: -0.1 },
+                halfExtents: { x: 0.2, y: 0.12 },
+                rotation: 0.1,
+            },
+        };
+        const scene = buildEuclideanScene(PLANES, VIEWPORT, { inversion });
+        expect(scene.inversion).toEqual(inversion);
     });
 });

--- a/tests/unit/render/webgl/pipelineRegistry.test.ts
+++ b/tests/unit/render/webgl/pipelineRegistry.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { GEOMETRY_KIND } from "@/geom/core/types";
 import { resolveWebGLPipeline } from "@/render/webgl/pipelineRegistry";
+import { EUCLIDEAN_CIRCLE_INVERSION_PIPELINE_ID } from "@/render/webgl/pipelines/euclideanCircleInversionPipeline";
 import { EUCLIDEAN_HALF_PLANE_PIPELINE_ID } from "@/render/webgl/pipelines/euclideanHalfPlanePipeline";
 import { HYPERBOLIC_GEODESIC_PIPELINE_ID } from "@/render/webgl/pipelines/hyperbolicGeodesicPipeline";
+import { SCENE_IDS, SCENES_BY_ID } from "@/ui/scenes";
 import type { SceneDefinition } from "@/ui/scenes/types";
 
 import "@/render/webgl/pipelines/hyperbolicGeodesicPipeline";
 import "@/render/webgl/pipelines/euclideanHalfPlanePipeline";
+import "@/render/webgl/pipelines/euclideanCircleInversionPipeline";
 
 type MinimalSceneDefinition = Pick<
     SceneDefinition,
@@ -39,5 +42,11 @@ describe("resolveWebGLPipeline", () => {
             variant: "sample",
         });
         expect(registration.id).toBe(EUCLIDEAN_HALF_PLANE_PIPELINE_ID);
+    });
+
+    it("returns the inversion pipeline for the circle inversion scene", () => {
+        const scene = SCENES_BY_ID[SCENE_IDS.euclideanCircleInversion];
+        const registration = resolveWebGLPipeline(scene);
+        expect(registration.id).toBe(EUCLIDEAN_CIRCLE_INVERSION_PIPELINE_ID);
     });
 });

--- a/tests/unit/ui/circleInversionScene.test.ts
+++ b/tests/unit/ui/circleInversionScene.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { SCENE_IDS, SCENES_BY_ID } from "@/ui/scenes";
+
+describe("Circle Inversion scene definition", () => {
+    it("is registered with the expected variant and geometry", () => {
+        const inversionId = SCENE_IDS.euclideanCircleInversion;
+        expect(inversionId).toBeDefined();
+        const scene = SCENES_BY_ID[inversionId];
+        expect(scene).toBeDefined();
+        expect(scene.geometry).toBe("euclidean");
+        expect(scene.variant).toBe("circle-inversion");
+        expect(scene.supportsHandles).toBe(false);
+    });
+
+    it("provides an inversion configuration with fixed circle and rectangle", () => {
+        const inversionId = SCENE_IDS.euclideanCircleInversion;
+        const scene = SCENES_BY_ID[inversionId];
+        expect(scene).toBeDefined();
+        if (!scene?.inversionConfig) {
+            throw new Error("Circle inversion scene configuration is missing");
+        }
+        const config = scene.inversionConfig;
+        expect(config.fixedCircle.radius).toBeGreaterThan(0);
+        expect(config.rectangle.halfExtents.x).toBeGreaterThan(0);
+        expect(config.rectangle.halfExtents.y).toBeGreaterThan(0);
+    });
+});


### PR DESCRIPTION
Closes #138

## 目的（Why）
- 背景/課題: Euclidean シーンで円反転を視覚化できず、他シェーダー拡張の検証が行えなかった。
- 目標: 固定円に対する図形の反転を WebGL 上で可視化できる新シーンとパイプラインを整備し、今後のテクスチャ応用の足場を作る。

## 変更点（What）
- Circle Inversion シーン定義と Storybook デモを追加し、矩形ドラッグ用の UI 状態を拡張。
- 反転描画専用の WebGL パイプライン／シェーダーを実装し、レンダリングエンジンに inversion Uniform を渡せるよう対応。
- 初期設定とパイプライン解決を検証するユニットテストを追加し、履歴ドキュメントに新シーンの検証手順を追記。

### 技術詳細（How）
- `CircleInversionState` を通じて固定円・矩形情報を scene 定義から WebGL パイプラインへ伝播。
- フラグメントシェーダーで矩形 SDF と円反転式を用い、元図形・反転像・円輪郭を同時描画。
- `EuclideanSceneHost` に矩形ドラッグ判定を追加し、レンダリング時に inversion 状態を渡すことで CPU 側の反転計算を不要化。

## スクリーンショット / 動作デモ（任意）
<!-- Storybook: Scenes/Circle Inversion -->

## 受け入れ条件（DoD）
- [x] 目的を満たすユーザーストーリーが確認できる
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm test` が緑（coverage v8）
- [x] 重要分岐のユニット/プロパティテストが追加されている
- [x] README/Docs/Storybook（該当時）が更新されている
- [x] アクセシビリティ: ラベル/フォーカス/キーボードが機能し重大違反なし

## 確認手順（Reviewer 向け）
```bash
pnpm i
pnpm lint && pnpm test
# Storybook チェック
pnpm storybook
```

## リスクとロールバック
- 影響範囲: Euclidean WebGL パイプライン、シーンホスト UI、Storybook
- リスク/懸念: 新シェーダーによる描画退行や低速化、矩形ドラッグのヒット判定が他シーンへ影響する可能性
- ロールバック指針: Circle Inversion シーン定義と `euclideanCircleInversionPipeline` を削除し、既存 Half-Plane パイプラインのみを残す

## Out of Scope（別PR）
- 矩形以外の図形やテクスチャの反転対応
- 固定円のドラッグ対応や UI パネル操作

## 関連 Issue / PR
- Refs #138

## 追加メモ（任意）
- Storybook: Scenes/Circle Inversion の Play で初期値検証が可能
- リリースノート案: Circle Inversion シーンが追加され、固定円による反転をリアルタイムに観察できます。